### PR TITLE
add optional chaining as metadata can be undefined

### DIFF
--- a/packages/ripple/src/compiler/phases/3-transform/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/index.js
@@ -44,7 +44,7 @@ function visit_function(node, context) {
 
 	let body = context.visit(node.body, state);
 
-	if (metadata.tracked === true) {
+	if (metadata?.tracked === true) {
 		return /** @type {FunctionExpression} */ ({
 			...node,
 			params: node.params.map((param) => context.visit(param, state)),


### PR DESCRIPTION
ran into an issue when calling a child component from App, this fixes it.  It looks like optional chaining was already above this line with the usage of `metadata`