### PR TITLE
Fixed reactive object property decrement not working issue

### DIFF
--- a/packages/ripple/src/runtime/internal/client/runtime.js
+++ b/packages/ripple/src/runtime/internal/client/runtime.js
@@ -766,6 +766,10 @@ export function increment(tracked, block) {
 	set(tracked, tracked.v + 1, block);
 }
 
+export function decrement(tracked, block) {
+	set(tracked, tracked.v - 1, block);
+}
+
 export function update_pre(tracked, block, d = 1) {
 	var value = get(tracked);
 
@@ -783,7 +787,12 @@ export function update_property(obj, property, block, d = 1) {
 	var value = get(tracked);
 	var result = d === 1 ? value++ : value--;
 
-	increment(tracked, block);
+	if (d === 1) {
+		increment(tracked, block);
+	} else {
+		decrement(tracked, block);
+	}
+
 	return result;
 }
 
@@ -798,7 +807,12 @@ export function update_pre_property(obj, property, block, d = 1) {
 	var value = get(tracked);
 	var result = d === 1 ? ++value : --value;
 
-	increment(tracked, block);
+	if (d === 1) {
+		increment(tracked, block);
+	} else {
+		decrement(tracked, block);
+	}
+
 	return result;
 }
 


### PR DESCRIPTION
### Issue: 
-    with reactive obj prop { $count : 1 }, obj.$count -- doesn't work. Instead it increase the count. 

### Fix: 
-    decrement the value instead of always incrementing it. 