### PR TITLE
fix: extension crashing on windows

### DIFF
--- a/packages/ripple-vscode-plugin/src/extension.js
+++ b/packages/ripple-vscode-plugin/src/extension.js
@@ -74,12 +74,12 @@ async function activate(context) {
 	const serverOptions = {
 		run: {
 			module: serverModule,
-			transport: lsp.TransportKind.ipc,
+			transport: lsp.TransportKind.stdio,
 			options: runOptions,
 		},
 		debug: {
 			module: serverModule,
-			transport: lsp.TransportKind.ipc,
+			transport: lsp.TransportKind.stdio,
 			options: debugOptions,
 		},
 	};

--- a/packages/ripple-vscode-plugin/src/server.js
+++ b/packages/ripple-vscode-plugin/src/server.js
@@ -6,6 +6,7 @@ const {
 } = require('@volar/language-server/node');
 const { createTypeScriptPlugins } = require('./ts.js');
 const { getRippleLanguagePlugin, createRippleDiagnosticPlugin } = require('./language.js');
+const { pathToFileURL } = require('url');
 
 const connection = createConnection();
 const server = createServer(connection);
@@ -24,7 +25,7 @@ connection.onInitialize(async (params) => {
 		);
 	}
 
-	ripple = await import(ripple_path);
+	ripple = await import(pathToFileURL(ripple_path).href);
 
 	const { typescript, diagnosticMessages } = loadTsdkByPath(tsdk, params.locale);
 


### PR DESCRIPTION
Changed the server connection from lsp.TransportKind.ipc to lsp.TransportKind.stdio and updated the server to use pathToFileURL when dynamically importing ripple_path.

Closes: #44

Notes:
- Using stdio is a bit slower than IPC, but it’s much more reliable with ESM on Windows.
- A faster IPC-based solution might be possible in the future, but this fixes the immediate crash.