### PR TITLE
add array.from support

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,19 @@ You'll need to import the array function from Ripple:
 import { array } from 'ripple';
 
 const arr = array(1, 2, 3);
+
+// or alternatively
+const arr = array(...[1, 2, 3]);
+```
+
+If you already have an array or array-like object, you can create a Ripple array by calling `array.from`.  It has the same signature as the standard `Array.from` function:
+
+```js
+import { array } from 'ripple';
+
+const existingArr = [1, 2, 3];
+
+const arr = array.from(existingArr);
 ```
 
 The `array` is a reactive Ripple array, and that means you can access properties normally using numeric index. However,
@@ -407,7 +420,7 @@ component App() {
       console.log("unmounted", node);
     };
   };
-  
+
   <div {@use ref}>{"Hello world"}</div>
 }
 ```

--- a/packages/ripple/src/runtime/array.js
+++ b/packages/ripple/src/runtime/array.js
@@ -213,3 +213,8 @@ export function get_all_elements(array) {
 export function array(...elements) {
 	return new RippleArray(...elements);
 }
+
+array.from = function(arrayLike, mapFn, thisArg) {
+	return RippleArray(...Array.from(arrayLike, mapFn, thisArg));
+};
+

--- a/packages/ripple/types/index.d.ts
+++ b/packages/ripple/types/index.d.ts
@@ -23,3 +23,16 @@ export interface RippleArray<T> extends Array<T> {
 }
 
 export declare function array<T>(...elements: T[]): RippleArray<T>;
+
+export declare namespace array {
+  function from<T>(
+    arrayLike: ArrayLike<T> | Iterable<T>
+  ): RippleArray<T>;
+
+  function from<T, U>(
+    arrayLike: ArrayLike<T> | Iterable<T>,
+    mapFn: (v: T, k: number) => U,
+    thisArg?: any
+  ): RippleArray<U>;
+}
+


### PR DESCRIPTION
`array.from` has the same signature as `Array.from` and can handle any array-like objects as well arrays. 