### PR TITLE
fix typo

### DIFF
--- a/packages/ripple/src/runtime/internal/client/render.js
+++ b/packages/ripple/src/runtime/internal/client/render.js
@@ -25,7 +25,7 @@ function get_setters(element) {
 	var element_proto = Element.prototype;
 
 	// Stop at Element, from there on there's only unnecessary setters we're not interested in
-	// Do not use contructor.name here as that's unreliable in some browser environments
+	// Do not use constructor.name here as that's unreliable in some browser environments
 	while (element_proto !== proto) {
 		descriptors = get_descriptors(proto);
 


### PR DESCRIPTION
`contructor` -> `constructor`