### PR TITLE
bump vscode version

### DIFF
--- a/packages/ripple-vscode-plugin/package.json
+++ b/packages/ripple-vscode-plugin/package.json
@@ -3,7 +3,7 @@
   "displayName": "Ripple for VS Code",
   "publisher": "ripplejs",
   "description": "Ripple JavaScript/TypeScript language support",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "author": "Dominic Gannaway",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
looks like it was missed in the latest bump commit:
https://github.com/trueadm/ripple/commit/5addb4c4130b51422126f9aafea5c3713f4149d4


marketplace still has the previous version from a few days ago:

<img width="363" height="174" alt="image" src="https://github.com/user-attachments/assets/e15f0d96-fc2d-4776-9110-5224414096a0" />