### PR TITLE
revert tinyglobby to valid version

### DIFF
--- a/templates/basic/package-lock.json
+++ b/templates/basic/package-lock.json
@@ -1061,7 +1061,7 @@
 			}
 		},
 		"node_modules/tinyglobby": {
-			"version": "0.2.15",
+			"version": "0.2.14",
 			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
 			"integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
 			"dev": true,


### PR DESCRIPTION
Looks like this package got caught in a find/replace all for 0.2.14 -> 0.2.15