### PR TITLE
playground improvements

### DIFF
--- a/website/playground.html
+++ b/website/playground.html
@@ -4,16 +4,29 @@
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Ripple playground</title>
+		<style>
+			html,
+			body {
+				margin: 0;
+				padding: 0;
+				height: 100vh;
+				overflow: hidden;
+			}
+
+			#container {
+				height: 100%;
+				width: 100%;
+			}
+		</style>
 
 		<script type="module">
-			import { createPlayground } from 'https://unpkg.com/livecodes';
+			import { createPlayground } from 'https://cdn.jsdelivr.net/npm/livecodes@0.11.1';
 
 			createPlayground('#container', {
 				appUrl: 'https://ripple.livecodes.pages.dev',
 				config: {
 					activeEditor: 'script',
 					script: {
-						order: 0,
 						language: 'ripple',
 						content: `import type { Component } from "ripple"
 
@@ -39,18 +52,19 @@ export default component App() {
 `,
 					},
 					markup: {
-						title: '',
+						language: 'html',
 						hideTitle: true,
 					},
 					style: {
-						title: '',
+						language: 'css',
 						hideTitle: true,
-            content: `body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif; background: hsl(0, 0%, 18%); color: #fff }`
+						content: `body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif; background: hsl(0, 0%, 18%); color: #fff }`,
 					},
 				},
 			});
 		</script>
 	</head>
-
-	<body id="container" style="height: 100vh; margin: 0; padding: 0; border-radius: 0px;" />
+	<body>
+		<div id="container" data-default-styles="false"></div>
+	</body>
 </html>


### PR DESCRIPTION
This PR adds some minor improvements to the playground.

- Pins the SDK version to avoid later breaking changes.
- By default, some styles are applied for embedded playgrounds (e.g. border, border-radius, etc.), which may not be ideally when the playground fills the page. [Default styles were disabled](https://livecodes.io/docs/sdk/js-ts#default-styles) and custom styles were added.
- Some other corrections for the use of the [SDK](https://livecodes.io/docs/sdk/js-ts).

I'm happy to continue maintaining the playground in the website. Please let me know (in [this issue](https://github.com/trueadm/ripple/issues/9)) if you need any modifications.
