### PR TITLE
fix `<code>` legibility in the playground

### DIFF
--- a/playground/src/App.ripple
+++ b/playground/src/App.ripple
@@ -36,6 +36,7 @@ export component App() {
       padding: 2px 6px;
       border-radius: 4px;
       font-family: "Courier New", monospace;
+      color: #333;
     }
 
     button {


### PR DESCRIPTION
This might just be a Linux issue (although it repros in both Chrome and Firefox), but the `<code>` in the playground is unreadable for me. Before and after:

<img width="341" height="189" alt="Screenshot from 2025-09-05 09-55-44" src="https://github.com/user-attachments/assets/f05b6cb5-336d-4cc6-a849-1a3b4fa965ac" />
<img width="341" height="189" alt="Screenshot from 2025-09-05 09-55-49" src="https://github.com/user-attachments/assets/ba5e1b70-5bc6-42f5-adbc-48a8e9cb3551" />

Very exciting project BTW!