### PR TITLE
use latest ripple version in playground

### DIFF
--- a/website/playground.html
+++ b/website/playground.html
@@ -25,6 +25,7 @@
 			createPlayground('#container', {
 				appUrl: 'https://ripple.livecodes.pages.dev',
 				config: {
+					customSettings: { ripple: { version: '0.2.16' } },
 					activeEditor: 'script',
 					script: {
 						language: 'ripple',

--- a/website/playground.html
+++ b/website/playground.html
@@ -9,13 +9,9 @@
 			body {
 				margin: 0;
 				padding: 0;
-				height: 100vh;
+				height: 100vh; /* for older browsers */
+				height: 100dvh;
 				overflow: hidden;
-			}
-
-			#container {
-				height: 100%;
-				width: 100%;
 			}
 		</style>
 
@@ -72,6 +68,6 @@ export default component App() {
 		</script>
 	</head>
 	<body>
-		<div id="container" data-default-styles="false"></div>
+		<div id="container" data-default-styles="false" data-height="100%"></div>
 	</body>
 </html>

--- a/website/playground.html
+++ b/website/playground.html
@@ -21,11 +21,17 @@
 
 		<script type="module">
 			import { createPlayground } from 'https://cdn.jsdelivr.net/npm/livecodes@0.11.1';
+			const apiUrl = 'https://data.jsdelivr.com/v1/packages/npm/ripple';
+
+			const pkg = await fetch(apiUrl)
+				.then((res) => res.json())
+				.catch(() => ({}));
+			const latest = pkg.tags?.latest || 'latest';
 
 			createPlayground('#container', {
 				appUrl: 'https://ripple.livecodes.pages.dev',
 				config: {
-					customSettings: { ripple: { version: '0.2.16' } },
+					customSettings: { ripple: { version: latest } },
 					activeEditor: 'script',
 					script: {
 						language: 'ripple',


### PR DESCRIPTION
This is a follow up for #76 

It checks latest published version from https://data.jsdelivr.com/v1/packages/npm/ripple
and uses that in the playground to avoid the cache problem outlined in #76

In addition, the css unit `dvh` is used instead of `vh` to avoid hiding the lower part (including console & compiled code viewer) in mobile.

<img width="360" height="720" alt="image" src="https://github.com/user-attachments/assets/2c0ca8dc-1087-4de0-895f-ed26b015751d" />
