### PR TITLE
prevent flashing loading message in playground

### DIFF
--- a/website/playground.html
+++ b/website/playground.html
@@ -26,6 +26,7 @@
 
 			createPlayground('#container', {
 				appUrl: 'https://ripple.livecodes.pages.dev',
+				loading: 'eager',
 				config: {
 					customSettings: { ripple: { version: latest } },
 					activeEditor: 'script',


### PR DESCRIPTION
By default, the embedded playground [lazy loads](https://livecodes.io/docs/sdk/js-ts#loading) (only loads when the user scrolls to it) to avoid loading multiple embedded playgrounds at the same time for performance. Until it loads, a "click to load" message is shown.

When the playground is in the initial view port like our case, it is better to change loading to `eager` to avoid this flashing load message.