### PR TITLE
feat: add slot syntax with Component.$$slot annotations

### DIFF
--- a/packages/ripple/tests/__snapshots__/slots.test.ripple.snap
+++ b/packages/ripple/tests/__snapshots__/slots.test.ripple.snap
@@ -1,0 +1,23 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`slot syntax > handles slot-annotated components 1`] = `
+<div>
+  <!---->
+  <div>
+    <div>
+      I am A
+    </div>
+    <!---->
+    <div>
+      other text
+    </div>
+    <!---->
+    <div>
+      I am B
+    </div>
+    <!---->
+  </div>
+  <!---->
+  
+</div>
+`;

--- a/packages/ripple/tests/slots.test.ripple
+++ b/packages/ripple/tests/slots.test.ripple
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { mount, flushSync } from 'ripple';
+
+describe('slot syntax', () => {
+	let container;
+
+	function render(component) {
+		mount(component, {
+			target: container
+		});
+	}
+
+	beforeEach(() => {
+		container = document.createElement('div');
+		document.body.appendChild(container);
+	});
+
+	afterEach(() => {
+		document.body.removeChild(container);
+		container = null;
+	});
+
+	it('handles slot-annotated components', () => {
+		component Button({ $A, $B, $children }) {
+			<div>
+				<$A />
+				<$children />
+				<$B />
+			</div>
+		}
+
+		component Counter() {
+			<div>{"I am A"}</div>
+		}
+
+		Counter.$$slot = 'A';
+
+		component Footer() {
+			<div>{"I am B"}</div>
+		}
+
+		Footer.$$slot = 'B';
+
+		component App() {
+			<Button>
+				<Counter />
+				<div>{"other text"}</div>
+				<Footer />
+			</Button>
+		}
+
+		render(App);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('passes props to slot components', () => {
+		component Layout({ $sidebar }) {
+			<div>
+				<$sidebar width="200px" />
+			</div>
+		}
+
+		component Sidebar({ width }) {
+			<div style={"width: " + width}>{"Sidebar"}</div>
+		}
+
+		Sidebar.$$slot = 'sidebar';
+
+		component App() {
+			<Layout>
+				<Sidebar />
+			</Layout>
+		}
+
+		render(App);
+
+		const sidebar = container.querySelector('div[style]');
+		expect(sidebar.style.width).toBe('200px');
+		expect(sidebar.textContent).toBe('Sidebar');
+	});
+
+	it('handles mixed slot and regular children', () => {
+		component Panel({ $title, $children }) {
+			<div>
+				<$title />
+				<$children />
+			</div>
+		}
+
+		component Title() {
+			<h1>{"Panel Title"}</h1>
+		}
+
+		Title.$$slot = 'title';
+
+		component App() {
+			<Panel>
+				<Title />
+				<p>{"Regular content"}</p>
+			</Panel>
+		}
+
+		render(App);
+
+		expect(container.querySelector('h1').textContent).toBe('Panel Title');
+		expect(container.querySelector('p').textContent).toBe('Regular content');
+	});
+});


### PR DESCRIPTION
# A proposal to https://github.com/trueadm/ripple/issues/50, created by Claude Code

## Summary

Adds a new slot syntax using `Component.$$slot = 'slotName'` annotations that provides a cleaner alternative to inline component definitions within JSX elements. To eliminate duplication of inline slot notations and enable better component composition:

in ui library:

```jsx
component Button({ $leadingIcon, $children, $trailingIcon ]) {
  <button>
    <span class='button-leading-icon'><$leadingIcon /></span>
    <$children />
    <span class='button-trailing-icon'><$trailingIcon /></span>
  </button>
}

component LeadingIcon({ icon }) { <svg>{icon}</svg> }
Header.$$slot = 'leadingIcon'

component TrailingIcon({ icon }) { <svg>{icon}</svg> }
Footer.$$slot = 'trailingIcon'
```

in app:

```jsx
<Button>
  <LeadingIcon icon={iconA} />
  {"Label"}
  <TrailingIcon icon={iconB} />
</Button>
```

without the slot notation, user has to do

```jsx
<Button>
  component leadingIcon() { <LeadingIcon icon={iconA} /> }
  {"Label"}
  component trailingIcon() { <TrailingIcon icon={iconB} /> }
</Button>
```

**Imagine you have many buttons on a single page, how it will be**

---

Some people would say, why not just

```
<Button
  $leadingIcon={<LeadingIcon icon={iconA} />}
  $trailingIcon={<TrailingIcon icon={iconB} />}
>
  {'Label"}
</Button>
```

Sure that works without changing anything, but this is not how WC's template/slot works
Personally I don't like this **fat props thin children** style, and nowadays the composition style is prevailing, thought it makes Accessibility support more complex(context) and style challenging(presence detection)