### PR TITLE
fix: handle single array argument in ripple array constructor

### DIFF
--- a/packages/ripple/src/runtime/array.js
+++ b/packages/ripple/src/runtime/array.js
@@ -49,6 +49,11 @@ export class RippleArray extends Array {
 	}
 
 	constructor(...elements) {
+		// RippleArray(1, 2, 3) or RippleArray([1, 2, 3])
+		if(Array.isArray(elements[0]) && elements.length === 1) {
+			elements = elements[0];
+		}
+
 		super(...elements);
 
 		var block = safe_scope();


### PR DESCRIPTION
Support `new RippleArray(1, 2, 3)` or `new RippleArray([1, 2, 3])`