### PR TITLE
Preview PRs in playground

### DIFF
--- a/.github/workflows/livecodes-post-comment.yml
+++ b/.github/workflows/livecodes-post-comment.yml
@@ -1,0 +1,21 @@
+name: comment
+
+on:
+  workflow_run:
+    workflows: ['livecodes'] # the workflow that created the artifact
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - uses: live-codes/pr-comment-from-artifact@v1
+        with:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/livecodes-preview.yml
+++ b/.github/workflows/livecodes-preview.yml
@@ -1,0 +1,14 @@
+name: livecodes
+
+on: [pull_request]
+
+jobs:
+  build_and_prepare:
+    runs-on: ubuntu-latest
+    name: Generate Playgrounds
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build and generate
+        uses: live-codes/preview-in-livecodes@v1

--- a/.livecodes/playground.json
+++ b/.livecodes/playground.json
@@ -1,0 +1,18 @@
+{
+	"appUrl": "https://ripple.livecodes.pages.dev",
+	"config": {
+		"customSettings": {
+			"ripple": { "version": "pr:ripple@{{LC::SHORT_SHA}}" }
+		},
+		"title": "Ripple Playground: {{LC::SHORT_SHA}}",
+		"activeEditor": "script",
+		"script": {
+			"language": "ripple",
+			"content": "import type { Component } from \"ripple\"\n\nexport default component App() {\n  <div class=\"container\">\n    let $count = 0;\n\n    <button onClick={() => $count++}>{$count}</button>\n\n    if ($count > 1) {\n      <div>{'Greater than 1!'}</div>\n    }\n  </div>\n\n  <style>\n    button {\n      padding: 1rem;\n      font-size: 1rem;\n      cursor: pointer;\n    }\n  </style>\n}\n"
+		},
+		"style": {
+			"language": "css",
+			"content": "body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif; background: hsl(0, 0%, 18%); color: #fff }"
+		}
+	}
+}


### PR DESCRIPTION
This PR adds github actions to preview PR changes in playground. See [Preview in LiveCodes](https://github.com/live-codes/preview-in-livecodes).

It uses pkg.pr.new to load Ripple compiler, runtime and formatter so that they can be tried in the playground before merge.

Example: https://github.com/hatemhosny/racing-bars/pull/211#issuecomment-3272401255

<img width="1588" height="957" alt="image" src="https://github.com/user-attachments/assets/b6753779-34ef-4ff5-8126-2a0d3845e0d8" />

Please note: 
- The GH actions need to be merged to the main branch to work ([details](https://github.com/live-codes/preview-in-livecodes?tab=readme-ov-file#usage)).
- This needs the pkg.pr.new packages to be available.