### PR TITLE
Fix nested variable scoping for reactive attributes

### DIFF
--- a/packages/ripple/src/compiler/phases/3-transform/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/index.js
@@ -398,6 +398,7 @@ const visitors = {
 
 		if (is_dom_element) {
 			let class_attribute = null;
+			const local_updates = [];
 
 			state.template.push(`<${node.id.name}`);
 
@@ -422,7 +423,7 @@ const visitors = {
 							const expression = visit(attr.value, state);
 
 							if (name === '$value') {
-								state.update.push(b.stmt(b.call('$.set_value', id, expression)));
+								local_updates.push(b.stmt(b.call('$.set_value', id, expression)));
 							} else {
 								state.init.push(b.stmt(b.call('$.set_value', id, expression)));
 							}
@@ -435,7 +436,7 @@ const visitors = {
 							const expression = visit(attr.value, state);
 
 							if (name === '$checked') {
-								state.update.push(b.stmt(b.call('$.set_checked', id, expression)));
+								local_updates.push(b.stmt(b.call('$.set_checked', id, expression)));
 							} else {
 								state.init.push(b.stmt(b.call('$.set_checked', id, expression)));
 							}
@@ -447,7 +448,7 @@ const visitors = {
 							const expression = visit(attr.value, state);
 
 							if (name === '$selected') {
-								state.update.push(b.stmt(b.call('$.set_selected', id, expression)));
+								local_updates.push(b.stmt(b.call('$.set_selected', id, expression)));
 							} else {
 								state.init.push(b.stmt(b.call('$.set_selected', id, expression)));
 							}
@@ -523,9 +524,9 @@ const visitors = {
 							const expression = visit(attr.value, state);
 
 							if (is_dom_property(attribute)) {
-								state.update.push(b.stmt(b.assignment('=', b.member(id, attribute), expression)));
+								local_updates.push(b.stmt(b.assignment('=', b.member(id, attribute), expression)));
 							} else {
-								state.update.push(
+								local_updates.push(
 									b.stmt(b.call('$.set_attribute', id, b.literal(attribute), expression)),
 								);
 							}
@@ -566,7 +567,7 @@ const visitors = {
 					}
 
 					if (class_attribute.name.name === '$class') {
-						state.update.push(b.stmt(b.call('$.set_class', id, expression)));
+						local_updates.push(b.stmt(b.call('$.set_class', id, expression)));
 					} else {
 						state.init.push(b.stmt(b.call('$.set_class', id, expression)));
 					}
@@ -590,6 +591,8 @@ const visitors = {
 			const update = [];
 
 			transform_children(node.children, { visit, state: { ...state, init, update }, root: false });
+
+			update.push(...local_updates);
 
 			if (init.length > 0) {
 				state.init.push(b.block(init));

--- a/packages/ripple/tests/basic.test.ripple
+++ b/packages/ripple/tests/basic.test.ripple
@@ -811,4 +811,25 @@ describe('basic', () => {
 		flushSync();
 		expect(greetingP.textContent).toBe('Hello, User!');
 	});
+
+	it('renders with reactive attributes with nested reactive attributes', () => {
+		component App() {
+			let $value = 'parent-class';
+
+			<p class={$value}>{'Colored parent value'}</p>
+
+			<div>
+				let $nested = 'nested-class';
+
+				<p class={$nested}>{'Colored nested value'}</p>
+			</div>
+		}
+
+		render(App);
+
+		const paragraphs = container.querySelectorAll('p');
+
+		expect(paragraphs[0].className).toBe('parent-class');
+		expect(paragraphs[1].className).toBe('nested-class');
+	});
 });


### PR DESCRIPTION
Modified the Element handler in the transform phase to ensure reactive attribute processing happens within the same scope as child variable declarations:
- Collect reactive attribute updates locally during initial processing
- Defer reactive attribute processing until after children are processed
- Add reactive attributes to child scope so they can access variables declared in children

**Problem**
When declaring reactive variables inside JSX elements and referencing them in reactive attributes on child elements, the compiler would generate JavaScript with incorrect scoping. Variables declared inside JSX elements were not accessible to reactive attributes on child elements within the same scope, causing `ReferenceError: [variable] is not defined` at runtime.
See issue: #118

The compiler was processing reactive attributes ($class, $value, $checked, etc.) outside the child scope block where variables were declared. This created a JavaScript scoping issue where:
- Variable declarations were wrapped in child scope blocks
- Reactive attribute processing happened in the parent scope
- Variables were not accessible across scope boundaries 