### PR TITLE
fix: implement reactive tuple array support for issue #179

### DIFF
--- a/packages/ripple/src/compiler/phases/3-transform/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/index.js
@@ -1074,17 +1074,9 @@ const visitors = {
 			if (element === null) {
 				elements.push(null);
 			} else if (element.type === 'Identifier' && is_tracked_name(element.name)) {
-				const metadata = { tracking: false, await: false };
-				const tracked_identifier = context.visit(element, { ...context.state, metadata });
-
-				if (metadata.tracking) {
-					tracked.push(b.literal(i));
-					elements.push(
-						b.call('$.computed_property', b.thunk(tracked_identifier), b.id('__block')),
-					);
-				} else {
-					elements.push(tracked_identifier);
-				}
+				// Preserve reference to the original tracked node rather than its value
+				tracked.push(b.literal(i));
+				elements.push(context.visit(element));
 			} else {
 				const metadata = { tracking: false, await: false };
 				elements.push(context.visit(element, { ...context.state, metadata }));

--- a/packages/ripple/src/runtime/internal/client/runtime.js
+++ b/packages/ripple/src/runtime/internal/client/runtime.js
@@ -834,6 +834,12 @@ export function tracked_object(obj, properties, block) {
 				tracked_property = computed(initial, block);
 				initial = run_computed(/** @type {Computed} */ (tracked_property));
 				obj[property] = initial;
+			} else if (initial && typeof initial === 'object' && initial.f !== undefined && (initial.f & TRACKED) !== 0) {
+				// If the initial value is already a tracked node, use it directly
+				tracked_property = /** @type {Tracked | Computed} */ (initial);
+				// Update the plain property to reflect current tracked value
+				var current_value = get(tracked_property);
+				obj[property] = current_value;
 			} else {
 				tracked_property = tracked(initial, block);
 			}

--- a/packages/ripple/tests/reactive-tuple-array.test.ripple
+++ b/packages/ripple/tests/reactive-tuple-array.test.ripple
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { mount, flushSync } from 'ripple';
+
+describe('reactive tuple arrays', () => {
+	let container;
+
+	function render(component) {
+		mount(component, {
+			target: container
+		});
+	}
+
+	beforeEach(() => {
+		container = document.createElement('div');
+		document.body.appendChild(container);
+	});
+
+	afterEach(() => {
+		document.body.removeChild(container);
+		container = null;
+	});
+
+	it('should update reactive variables when tuple array is modified by index', () => {
+		component App() {
+			let $first = 0;
+			let $second = 0;
+			const arr = [$first, $second];
+
+			<button onClick={() => arr[0]++}>{'arr[0]: ' + arr[0]}</button>
+			<pre class="first">{'$first: ' + $first}</pre>
+			<pre class="second">{'$second: ' + $second}</pre>
+			<pre class="array">{'arr: ' + JSON.stringify(arr)}</pre>
+		}
+
+		render(App);
+
+		const button = container.querySelector('button');
+		const firstPre = container.querySelector('.first');
+		const secondPre = container.querySelector('.second');
+		const arrayPre = container.querySelector('.array');
+
+		// Initial state
+		expect(button.textContent).toBe('arr[0]: 0');
+		expect(firstPre.textContent).toBe('$first: 0');
+		expect(secondPre.textContent).toBe('$second: 0');
+		expect(arrayPre.textContent).toBe('arr: [0,0]');
+
+		// Click to increment arr[0]
+		button.click();
+		flushSync();
+
+		// Both the array element AND the original reactive variable should be updated
+		expect(button.textContent).toBe('arr[0]: 1');
+		expect(firstPre.textContent).toBe('$first: 1');
+		expect(secondPre.textContent).toBe('$second: 0'); // Should remain unchanged
+		expect(arrayPre.textContent).toBe('arr: [1,0]');
+
+		// Click again to increment arr[0] once more
+		button.click();
+		flushSync();
+
+		expect(button.textContent).toBe('arr[0]: 2');
+		expect(firstPre.textContent).toBe('$first: 2');
+		expect(secondPre.textContent).toBe('$second: 0');
+		expect(arrayPre.textContent).toBe('arr: [2,0]');
+	});
+});


### PR DESCRIPTION
**Description:**
```markdown
## Summary
Fixes #179 - Reactive tuple array is not reactively updating its members on changes by index

## Problem
When creating an array with reactive variables like `const arr = [$first, $second]`, updating `arr[0]++` would not reactively update the original `$first` variable.

## Solution
1. **Compiler Fix**: Modified array literal compilation to preserve tracked variable references
2. **Runtime Fix**: Enhanced `tracked_object` to reuse existing tracked nodes instead of creating new ones
3. **Test Coverage**: Added comprehensive test case to verify the fix

## Changes
- `packages/ripple/src/compiler/phases/3-transform/index.js`: Simplified array element handling for tracked variables
- `packages/ripple/src/runtime/internal/client/runtime.js`: Added logic to detect and reuse existing tracked nodes
- `packages/ripple/tests/reactive-tuple-array.test.ripple`: New test case verifying the fix

## Testing
- All existing tests pass ✅
- New test case covers the reported issue
- Ensures bidirectional reactivity between array elements and original variables

## Verification
With this fix, the following now works as expected:
```javascript
let $first = 0;
const arr = [$first];
arr[0]++; // Now correctly updates both arr[0] and $first
```
```

### 6. Files Changed
The following files were modified:
- `packages/ripple/src/compiler/phases/3-transform/index.js`
- `packages/ripple/src/runtime/internal/client/runtime.js`  
- `packages/ripple/tests/reactive-tuple-array.test.ripple` (new file)

## Commit Hash
`0446c56` - fix: implement reactive tuple array support for issue #179
