### PR TITLE
fix version comparison for extension auto-publish workflow

### DIFF
--- a/.github/workflows/vsix.yml
+++ b/.github/workflows/vsix.yml
@@ -23,7 +23,7 @@ jobs:
               run: |
                   # jq -r returns raw string
                   CURRENT_VERSION=$(jq -r .version package.json)
-                  PREVIOUS_VERSION=$(git show HEAD~1:package.json | jq -r .version)
+                  PREVIOUS_VERSION=$(git show HEAD~1:./package.json | jq -r .version)
 
                   echo "Current version:  ${CURRENT_VERSION}"
                   echo "Previous version: ${PREVIOUS_VERSION}"


### PR DESCRIPTION
Fixes https://github.com/trueadm/ripple/actions/runs/17696573863/job/50296820627

ran git show on the monorepo package.json rather than the extension's, so use the relative path instead.

```
CURRENT_VERSION=$(jq -r .version package.json)
PREVIOUS_VERSION=$(git show HEAD~1:package.json | jq -r .version) <------
# rest omitted for brevity

Outputs: 
Current version:  0.0.10
Previous version: null
Version was changed: null -> 0.0.10
```