### PR TITLE
fix: Fixed TS errors in templates and added .gitignore

### DIFF
--- a/packages/create-ripple/src/lib/project-creator.js
+++ b/packages/create-ripple/src/lib/project-creator.js
@@ -110,8 +110,9 @@ export async function createProject({
 		const spinner5 = ora('Initializing Git repository...').start();
 		try {
 			execSync('git init', { cwd: projectPath, stdio: 'ignore' });
-			execSync('git add .', { cwd: projectPath, stdio: 'ignore' });
-			execSync('git commit -m "Initial commit"', { cwd: projectPath, stdio: 'ignore' });
+			// We should not automatically commit without asking user, so I have currently commented the code:
+			// execSync('git add .', { cwd: projectPath, stdio: 'ignore' });
+			// execSync('git commit -m "Initial commit"', { cwd: projectPath, stdio: 'ignore' });
 			spinner5.succeed('Git repository initialized');
 		} catch (error) {
 			spinner5.warn('Git initialization failed (optional)');

--- a/templates/basic/.gitignore
+++ b/templates/basic/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.env

--- a/templates/basic/ripple.d.ts
+++ b/templates/basic/ripple.d.ts
@@ -1,0 +1,1 @@
+declare module '*.ripple'


### PR DESCRIPTION
- Fixed scaffolding templates to run only `git init` (currently commented to not run auto `git add` and `git commit`).
- Added missing type declaration file ripple.d.ts for `*.ripple` files to fix TS error in templates:  
  `Cannot find module './App.ripple' or its corresponding type declaration`.