### PR TITLE
fix source location for style tag

### DIFF
--- a/packages/ripple/src/utils/patterns.js
+++ b/packages/ripple/src/utils/patterns.js
@@ -12,6 +12,7 @@ export const regex_whitespaces_strict = /[ \t\n\r\f]+/g;
 
 export const regex_only_whitespaces = /^[ \t\n\r\f]+$/;
 
+export const regex_newline_characters = /\n/g;
 export const regex_not_newline_characters = /[^\n]/g;
 
 export const regex_is_valid_identifier = /^[a-zA-Z_$][a-zA-Z_$0-9]*$/;


### PR DESCRIPTION
Fixes #103 

Problem: The css content was skipped when computing source locations, leading to wrong values starting at the closing `style` tag.

Solution: Adjust the curLine and lineStart manually to take new lines into account.

I'm open to adding some tests in compiler.test.ripple if this approach seems ok