### PR TITLE
fix parser's css content extraction

### DIFF
--- a/packages/ripple/src/compiler/phases/1-parse/index.js
+++ b/packages/ripple/src/compiler/phases/1-parse/index.js
@@ -413,9 +413,9 @@ function RipplePlugin(config) {
 					}
 				} else {
 					if (open.name.name === 'style') {
-						// jsx_parseOpeningElementAt can treat a html element selector as an identifier and read it
-						// In that case, need to backtrack to include it in the css content
-						const start = this.pos - (this.value?.length ?? 1)
+						// jsx_parseOpeningElementAt treats ID selectors (ie. #myid) or type selectors (ie. div) as identifier and read it
+						// So backtrack to the end of the <style> tag to make sure everything is included
+						const start = open.end;
 						const input = this.input.slice(start);
 						const end = input.indexOf('</style>');
 						const content = input.slice(0, end);
@@ -428,7 +428,7 @@ function RipplePlugin(config) {
 
 						const newLines = content.match(regex_newline_characters)?.length;
 						if (newLines) {
-							this.curLine += newLines;
+							this.curLine = open.loc.end.line + newLines;
 							this.lineStart = start + content.lastIndexOf('\n') + 1;
 						}
 						this.pos = start + content.length + 1;

--- a/packages/ripple/tests/compiler.test.ripple
+++ b/packages/ripple/tests/compiler.test.ripple
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mount, RippleArray } from 'ripple';
+import { parse } from 'ripple/compiler'
 
 describe('compiler success tests', () => {
   let container;
@@ -18,6 +19,30 @@ describe('compiler success tests', () => {
 	afterEach(() => {
 		document.body.removeChild(container);
 		container = null;
+	});
+
+	
+	it('Parses style content correctly', () => {
+		const source = `export component App() {
+  <div id="myid" class="myclass">{"Hello World"}</div>
+  
+  <style>#style</style>
+}`;
+		const style1 = '.myid {color: green }';
+		const style2 = '#myid {color: green }';
+		const style3 = 'div {color: green }';
+		
+		let input = source.replace('#style', style1);
+		let ast = parse(input);
+		expect(ast.body[0].declaration.css.source).toEqual(style1);
+
+		input = source.replace('#style', style2);
+		ast = parse(input);
+		expect(ast.body[0].declaration.css.source).toEqual(style2);
+
+		input = source.replace('#style', style3);
+		ast = parse(input);
+		expect(ast.body[0].declaration.css.source).toEqual(style3);
 	});
 
   it('renders without crashing', () => {


### PR DESCRIPTION
Should fix #173 

css content extraction was still not properly handled when starting with an id selector. The # was not included in the parser's identifier value.

Did not fix the failing tests in create-ripple since they are unrelated to this change. Seems like a windows/unix path issue 