### PR TITLE
fix: apply styles based on reactive attributes

### DIFF
--- a/packages/ripple/src/compiler/phases/2-analyze/prune.js
+++ b/packages/ripple/src/compiler/phases/2-analyze/prune.js
@@ -405,7 +405,9 @@ function attribute_matches(node, name, expected_value, operator, case_insensitiv
 		if (attribute.type === 'SpreadAttribute') return true;
 
 		if (attribute.type !== 'Attribute') continue;
-		if (attribute.name.name.toLowerCase() !== name.toLowerCase()) continue;
+
+		const lowerCaseName = name.toLowerCase();
+		if (![lowerCaseName, `$${lowerCaseName}`].includes(attribute.name.name.toLowerCase())) continue;
 
 		if (expected_value === null) return true;
 

--- a/packages/ripple/tests/basic.test.ripple
+++ b/packages/ripple/tests/basic.test.ripple
@@ -76,6 +76,12 @@ describe('basic', () => {
 
 			<button onClick={() => $active = !$active}>{'Toggle'}</button>
 			<div $class={$active ? 'active' : 'inactive'}>{'Dynamic Class'}</div>
+
+			<style>
+				.active {
+					color: green;
+				}
+			</style>
 		}
 
 		render(Basic);
@@ -83,17 +89,17 @@ describe('basic', () => {
 		const button = container.querySelector('button');
 		const div = container.querySelector('div');
 
-		expect(div.className).toBe('inactive');
+		expect(Array.from(div.classList).some(className => className.startsWith('ripple-'))).toBe(true);
+		expect(div.classList.contains('inactive')).toBe(true);
+		
+		button.click();
+		flushSync();
+		expect(div.classList.contains('active')).toBe(true);
 
 		button.click();
 		flushSync();
 
-		expect(div.className).toBe('active');
-
-		button.click();
-		flushSync();
-
-		expect(div.className).toBe('inactive');
+		expect(div.classList.contains('inactive')).toBe(true);
 	});
 
 	it('render dynamic id attribute', () => {


### PR DESCRIPTION
Fixes #194 

This PR fixes a bug where the compiler did not correctly handle attributes starting with a dollar sign, such as `$class`.
`attribute_matches` function has been updated to correctly recognize attributes prefixed with a dollar sign.