### PR TITLE
change decorator api to refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,41 @@ Lastly, you can use refs on composite components.
 
 When passing refs to composite components (rather than HTML elements) as shown above, they will be passed a `Symbol` property, as they are not named. This still means that it can be spread to HTML template elements later on and still work.
 
+#### createRefKey
+
+Creates a unique object key that will be recognised as a ref when the object is spread onto an element.
+This allows programmatic assignment of refs without relying directly on the `{ref ...}` template syntax.
+
+```jsx
+import { createRefKey } from 'ripple';
+
+export component App() {
+  let $value = '';
+
+  const props = {
+    id: "example",
+    $value,
+    [createRefKey()]: (node) => {
+      const removeListener = node.addEventListener('input', (e) => $value = e.target.value);
+
+      return () => {
+        removeListener();
+      }
+    }
+  };
+
+  // applied to an element
+  <input type="text" {...props} />
+
+  // with composite component
+  <Input {...props} />
+}
+
+component Input({ id, $value, ...rest }) {
+  <input type="text" {id} {$value} {...rest} />
+}
+```
+
 ### Event Props
 
 Like React, events are props that start with `on` and then continue with an uppercase character, such as:

--- a/README.md
+++ b/README.md
@@ -592,10 +592,10 @@ component Person(props) {
 }
 ```
 
-### Decorators
+### Refs
 
-Ripple provides a consistent way to capture the underlying DOM element – decorators. Specifically, using
-the syntax `{@use fn}` where `fn` is a function that captures the DOM element. If you're familiar with other frameworks, then
+Ripple provides a consistent way to capture the underlying DOM element – refs. Specifically, using
+the syntax `{ref fn}` where `fn` is a function that captures the DOM element. If you're familiar with other frameworks, then
 this is identical to `{@attach fn}` in Svelte 5 and somewhat similar to `ref` in React. The hook function will receive
 the reference to the underlying DOM element.
 
@@ -603,7 +603,7 @@ the reference to the underlying DOM element.
 export component App() {
   let $node;
 
-  const ref = (node) => {
+  const divRef = (node) => {
     $node = node;
     console.log("mounted", node);
 
@@ -613,17 +613,17 @@ export component App() {
     };
   };
 
-  <div {@use ref}>{"Hello world"}</div>
+  <div {ref divRef}>{"Hello world"}</div>
 }
 ```
 
-You can also create `{@use}` functions inline.
+You can also create `{ref}` functions inline.
 
 ```jsx
 export component App() {
   let $node;
 
-  <div {@use (node) => {
+  <div {ref (node) => {
     $node = node;
     return () => $node = null;
   }}>{"Hello world"}</div>
@@ -637,17 +637,17 @@ thing. However, you can use this pattern to pass reactive properties.
 import { fadeIn } from 'some-library';
 
 export component App({ $ms }) {
-  <div {@use fadeIn({ $ms })}>{"Hello world"}</div>
+  <div {ref fadeIn({ $ms })}>{"Hello world"}</div>
 }
 ```
 
-Lastly, you can use decorators on composite components.
+Lastly, you can use refs on composite components.
 
 ```jsx
-<Image {@use (node) => console.log(node)} {...props} />
+<Image {ref (node) => console.log(node)} {...props} />
 ```
 
-When passing decorators to composite components (rather than HTML elements) as shown above, they will be passed a `Symbol` property, as they are not named. This still means that it can be spread to HTML template elements later on and still work.
+When passing refs to composite components (rather than HTML elements) as shown above, they will be passed a `Symbol` property, as they are not named. This still means that it can be spread to HTML template elements later on and still work.
 
 ### Event Props
 

--- a/packages/prettier-plugin-ripple/src/index.js
+++ b/packages/prettier-plugin-ripple/src/index.js
@@ -355,8 +355,8 @@ function printRippleNode(node, path, options, print, args) {
 			return parts;
 		}
 
-		case 'UseAttribute':
-			return concat(['{@use ', path.call(print, 'argument'), '}']);
+		case 'RefAttribute':
+			return concat(['{ref ', path.call(print, 'argument'), '}']);
 
 		case 'SpreadAttribute': {
 			const parts = ['{...', path.call(print, 'argument'), '}'];

--- a/packages/prettier-plugin-ripple/src/index.test.js
+++ b/packages/prettier-plugin-ripple/src/index.test.js
@@ -142,7 +142,7 @@ describe('prettier-plugin-ripple', () => {
 			const already_formatted = `export component App() {
   let $node;
 
-  const ref = node => {
+  const createRef = node => {
     $node = node;
     console.log('mounted', node);
 
@@ -159,7 +159,7 @@ describe('prettier-plugin-ripple', () => {
     c: 3,
   };
 
-  <div {@use ref}>{'Hello world'}</div>
+  <div {ref createRef}>{'Hello world'}</div>
 
   <style>
     div {

--- a/packages/ripple-vscode-plugin/syntaxes/ripple.tmLanguage.json
+++ b/packages/ripple-vscode-plugin/syntaxes/ripple.tmLanguage.json
@@ -304,6 +304,9 @@
 		"expression": {
 			"patterns": [
 				{
+					"include": "#jsx-ref-modifier"
+				},
+				{
 					"include": "#expressionWithoutIdentifiers"
 				},
 				{
@@ -6358,14 +6361,6 @@
 			},
 			"patterns": [
 				{
-					"match": "(\\@use)\\b\\s*",
-					"captures": {
-						"1": {
-							"name": "storage.modifier.js"
-						}
-					}
-				},
-				{
 					"include": "#expression"
 				}
 			]
@@ -6478,6 +6473,15 @@
 					"include": "#jsx-entities"
 				}
 			]
+		},
+		"jsx-ref-modifier": {
+			"name": "storage.modifier.js",
+			"match": "\\b(ref)(?=\\s+[_$[:alpha:]])",
+			"captures": {
+				"1": {
+					"name": "storage.modifier.js"
+				}
+			}
 		},
 		"jsx-tag-attributes-illegal": {
 			"name": "invalid.illegal.attribute.js",

--- a/packages/ripple/src/compiler/phases/1-parse/index.js
+++ b/packages/ripple/src/compiler/phases/1-parse/index.js
@@ -139,15 +139,11 @@ function RipplePlugin(config) {
 				}
 
 				if (this.eat(tt.braceL)) {
-					if (this.type.label === '@') {
-						this.next();
-						if (this.value !== 'use') {
-							this.unexpected();
-						}
+					if (this.value === 'ref') {
 						this.next();
 						node.argument = this.parseMaybeAssign();
 						this.expect(tt.braceR);
-						return this.finishNode(node, 'UseAttribute');
+						return this.finishNode(node, 'RefAttribute');
 					} else if (this.type === tt.ellipsis) {
 						this.expect(tt.ellipsis);
 						node.argument = this.parseMaybeAssign();

--- a/packages/ripple/src/compiler/phases/1-parse/index.js
+++ b/packages/ripple/src/compiler/phases/1-parse/index.js
@@ -141,6 +141,9 @@ function RipplePlugin(config) {
 				if (this.eat(tt.braceL)) {
 					if (this.value === 'ref') {
 						this.next();
+						if (this.type === tt.braceR) {
+							this.raise(this.start, '"ref" is a Ripple keyword and must be used in the form {ref fn}');
+						}
 						node.argument = this.parseMaybeAssign();
 						this.expect(tt.braceR);
 						return this.finishNode(node, 'RefAttribute');

--- a/packages/ripple/src/compiler/phases/3-transform/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/index.js
@@ -665,9 +665,9 @@ const visitors = {
 					}
 				} else if (attr.type === 'SpreadAttribute') {
 					spread_attributes.push(b.spread(b.call('$.spread_object', visit(attr.argument, state))));
-				} else if (attr.type === 'UseAttribute') {
+				} else if (attr.type === 'RefAttribute') {
 					const id = state.flush_node();
-					state.init.push(b.stmt(b.call('$.use', id, b.thunk(visit(attr.argument, state)))));
+					state.init.push(b.stmt(b.call('$.ref', id, b.thunk(visit(attr.argument, state)))));
 				}
 			}
 
@@ -770,8 +770,8 @@ const visitors = {
 							),
 						),
 					);
-				} else if (attr.type === 'UseAttribute') {
-					props.push(b.prop('init', b.call('$.use_prop'), visit(attr.argument, state), true));
+				} else if (attr.type === 'RefAttribute') {
+					props.push(b.prop('init', b.call('$.ref_prop'), visit(attr.argument, state), true));
 				} else if (attr.type === 'AccessorAttribute') {
 					// # means it's an accessor to the runtime
 					tracked.push(b.literal('#' + attr.name.name));
@@ -1409,12 +1409,12 @@ function transform_ts_child(node, context) {
 		const children = [];
 		let has_children_props = false;
 
-		// Filter out UseAttributes and handle them separately
-		const use_attributes = [];
+		// Filter out RefAttributes and handle them separately
+		const ref_attributes = [];
 		const attributes = node.attributes
 			.filter((attr) => {
-				if (attr.type === 'UseAttribute') {
-					use_attributes.push(attr);
+				if (attr.type === 'RefAttribute') {
+					ref_attributes.push(attr);
 					return false;
 				}
 				return true;
@@ -1438,10 +1438,10 @@ function transform_ts_child(node, context) {
 				}
 			});
 
-		// Add UseAttribute references separately for sourcemap purposes
-		for (const use_attr of use_attributes) {
+		// Add RefAttribute references separately for sourcemap purposes
+		for (const ref_attr of ref_attributes) {
 			const metadata = { await: false };
-			const argument = visit(use_attr.argument, { ...state, metadata });
+			const argument = visit(ref_attr.argument, { ...state, metadata });
 			state.init.push(b.stmt(argument));
 		}
 

--- a/packages/ripple/src/compiler/phases/3-transform/segments.js
+++ b/packages/ripple/src/compiler/phases/3-transform/segments.js
@@ -61,8 +61,8 @@ export function convert_source_map_to_mappings(source_map, source, generated_cod
 			);
 			const source_content = source.substring(source_offset, source_offset + segment_length);
 
-			// Skip mappings for UseAttribute syntax to avoid overlapping sourcemaps
-			if (source_content.includes('{@use ') || source_content.match(/\{\s*@use\s+/)) {
+			// Skip mappings for RefAttribute syntax to avoid overlapping sourcemaps
+			if (source_content.includes('{ref ') || source_content.match(/\{\s*ref\s+/)) {
 				continue;
 			}
 

--- a/packages/ripple/src/runtime/index.js
+++ b/packages/ripple/src/runtime/index.js
@@ -50,3 +50,4 @@ export { user_effect as effect } from './internal/client/blocks.js';
 
 export { Portal } from './internal/client/portal.js';
 
+export { ref_prop as createRefKey } from './internal/client/runtime.js';

--- a/packages/ripple/src/runtime/internal/client/blocks.js
+++ b/packages/ripple/src/runtime/internal/client/blocks.js
@@ -99,23 +99,23 @@ export function async(fn) {
  * @param {() => (element: Element) => (void | (() => void))} get_fn
  * @returns {Block}
  */
-export function use(element, get_fn) {
+export function ref(element, get_fn) {
 	/** @type {(element: Element) => (void | (() => void) | undefined)} */
-	var use_fn;
+	var ref_fn;
 	/** @type {Block | null} */
 	var e;
 
 	return block(RENDER_BLOCK, () => {
-		if (use_fn !== (use_fn = get_fn())) {
+		if (ref_fn !== (ref_fn = get_fn())) {
 			if (e) {
 				destroy_block(e);
 				e = null;
 			}
 
-			if (use_fn) {
+			if (ref_fn) {
 				e = branch(() => {
 					effect(() => {
-						return use_fn(element);
+						return ref_fn(element);
 					});
 				});
 			}

--- a/packages/ripple/src/runtime/internal/client/constants.js
+++ b/packages/ripple/src/runtime/internal/client/constants.js
@@ -22,5 +22,5 @@ export var UNINITIALIZED = Symbol();
 export var TRACKED_OBJECT = Symbol();
 export var SPREAD_OBJECT = Symbol();
 export var COMPUTED_PROPERTY = Symbol();
-export var USE_PROP = '@use';
+export var REF_PROP = 'ref';
 export var ARRAY_SET_INDEX_AT = Symbol();

--- a/packages/ripple/src/runtime/internal/client/index.js
+++ b/packages/ripple/src/runtime/internal/client/index.js
@@ -9,7 +9,7 @@ export {
 	set_selected,
 } from './render.js';
 
-export { render, render_spread, async, use } from './blocks.js';
+export { render, render_spread, async, ref } from './blocks.js';
 
 export { event, delegate } from './events.js';
 
@@ -42,7 +42,7 @@ export {
 	push_component,
 	pop_component,
 	untrack,
-	use_prop,
+	ref_prop,
 	fallback,
 	exclude_from_object,
 } from './runtime.js';

--- a/packages/ripple/src/runtime/internal/client/render.js
+++ b/packages/ripple/src/runtime/internal/client/render.js
@@ -1,5 +1,5 @@
-import { destroy_block, use } from './blocks';
-import { USE_PROP } from './constants';
+import { destroy_block, ref } from './blocks';
+import { REF_PROP } from './constants';
 import { get_descriptors, get_own_property_symbols, get_prototype_of } from './utils';
 
 export function set_text(text, value) {
@@ -174,16 +174,16 @@ export function apply_element_spread(element, fn) {
 		}
 
 		for (const symbol of get_own_property_symbols(next)) {
-			var use_fn = next[symbol];
+			var ref_fn = next[symbol];
 
-			if (symbol.description === USE_PROP && (!prev || use_fn !== prev[symbol])) {
+			if (symbol.description === REF_PROP && (!prev || ref_fn !== prev[symbol])) {
 				if (effects[symbol]) {
 					destroy_block(effects[symbol]);
 				}
-				effects[symbol] = use(element, () => use_fn);
+				effects[symbol] = ref(element, () => ref_fn);
 			}
 
-			next[symbol] = use_fn;
+			next[symbol] = ref_fn;
 		}
 
 		set_attributes(element, next);

--- a/packages/ripple/src/runtime/internal/client/runtime.js
+++ b/packages/ripple/src/runtime/internal/client/runtime.js
@@ -25,7 +25,7 @@ import {
 	TRACKED_OBJECT,
 	TRY_BLOCK,
 	UNINITIALIZED,
-	USE_PROP,
+	REF_PROP,
 	ARRAY_SET_INDEX_AT,
 } from './constants';
 import { capture, suspend } from './try.js';
@@ -1203,8 +1203,8 @@ export function pop_component() {
 	active_component = component.p;
 }
 
-export function use_prop() {
-	return Symbol(USE_PROP);
+export function ref_prop() {
+	return Symbol(REF_PROP);
 }
 
 /**

--- a/packages/ripple/tests/ref.test.ripple
+++ b/packages/ripple/tests/ref.test.ripple
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mount, flushSync, RippleArray } from 'ripple';
 
-describe('@use element decorators', () => {
+describe('refs', () => {
 	let container;
 
 	function render(component) {
@@ -24,7 +24,7 @@ describe('@use element decorators', () => {
 		let div;
 
 		component Component() {
-			<div {@use (node) => { div = node; }}>{'Hello World'}</div>
+			<div {ref (node) => { div = node; }}>{'Hello World'}</div>
 		}
 		render(Component);
 		flushSync();
@@ -37,11 +37,11 @@ describe('@use element decorators', () => {
 		component Component() {
 			let items = RippleArray.from([1, 2, 3]);
 
-			function ref(node) {
+			function componentRef(node) {
 				_node = node;
 			}
 
-			<Child {@use ref} {items} />
+			<Child {ref componentRef} {items} />
 		}
 
 		component Child(props) {

--- a/packages/ripple/types/index.d.ts
+++ b/packages/ripple/types/index.d.ts
@@ -79,3 +79,5 @@ declare global {
         // Add other runtime functions as needed for TypeScript analysis
     };
 }
+
+export declare function createRefKey(): symbol;

--- a/website/llms.txt
+++ b/website/llms.txt
@@ -417,15 +417,15 @@ component StyledComponent() {
 }
 ```
 
-### DOM References (Decorators)
+### DOM References (Refs)
 
-Use `{@use fn}` syntax to capture DOM element references:
+Use `{ref fn}` syntax to capture DOM element references:
 
 ```ripple
 export component App() {
   let $node;
 
-  const ref = (node) => {
+  const divRef = (node) => {
     $node = node;
     console.log("mounted", node);
     
@@ -434,13 +434,13 @@ export component App() {
     };
   };
 
-  <div {@use ref}>{"Hello world"}</div>
+  <div {ref divRef}>{"Hello world"}</div>
 }
 ```
 
-Inline decorators:
+Inline refs:
 ```ripple
-<div {@use (node) => console.log(node)}>{"Content"}</div>
+<div {ref (node) => console.log(node)}>{"Content"}</div>
 ```
 
 ## Built-in APIs


### PR DESCRIPTION
The `{@use}` decorator feature has always felt cumbersome, as people associate capturing the DOM element using a `ref`. Plus the `@` isn't something we've promoted before, so it doesn't make sense to use it here either. We can simplify this this feature to be `{ref fn}` or `{ref () => {…} }` or `{ref fn(a, b}`.