### PR TITLE
ci: add npm provenance check for dependencies

### DIFF
--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -1,0 +1,28 @@
+on:
+    push:
+        branches: [main, develop]
+        tags: ["!**"]
+        paths: ["packages/**"]
+    pull_request:
+        branches: ["main"]
+
+permissions:
+    contents: read
+
+jobs:
+    check-provenance:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+            - name: Check provenance downgrades
+              uses: danielroe/provenance-action@main
+              id: check
+              with:
+                  fail-on-provenance-change: true # optional, default: false
+              #   lockfile: pnpm-lock.yaml      # optional, auto-detects
+              #   base-ref: origin/main         # optional, default: origin/main
+              #   fail-on-downgrade: true       # optional, default: true
+            - name: Print result
+              run: "echo 'Downgraded: ${{ steps.check.outputs.downgraded }}'"


### PR DESCRIPTION
While we've avoided the recent supply chain attacks through pnpm's default of having to manually approve postinstalls, I think it's prudent that we take an active approach to supply-chain security.