### PR TITLE
fix: keep @ when formatting (prettier)

### DIFF
--- a/packages/prettier-plugin-ripple/src/index.js
+++ b/packages/prettier-plugin-ripple/src/index.js
@@ -364,11 +364,13 @@ function printRippleNode(node, path, options, print, args) {
 		}
 
 		case 'Identifier':
+			
 			// Simple case - just return the name directly like Prettier core
+			const trackedPrefix  = node.tracked ? "@" : "";
 			if (node.typeAnnotation) {
-				return concat([node.name, ': ', path.call(print, 'typeAnnotation')]);
+				return concat([trackedPrefix + node.name, ': ', path.call(print, 'typeAnnotation')]);
 			}
-			return node.name;
+			return trackedPrefix + node.name;
 
 		case 'Literal':
 			return formatStringLiteral(node.value, options);

--- a/packages/prettier-plugin-ripple/src/index.test.js
+++ b/packages/prettier-plugin-ripple/src/index.test.js
@@ -315,6 +315,33 @@ export default component App() {
         const result = await format(input, { singleQuote: true });
         expect(result).toBe(expected);
     });
+    
+    it('should handle @ prefix', async () => {
+        const input = `export default component App() {
+  <div>
+    let count = track(0);
+    @count = 2;
+    console.log(@count);
+    console.log(count);
+    if (@count > 1) {
+      <button onClick={() => @count++}>{@count}</button>
+    }
+  </div>
+}`;
+        const expected = `export default component App() {
+  <div>
+    let count = track(0);
+    @count = 2;
+    console.log(@count);
+    console.log(count);
+    if (@count > 1) {
+      <button onClick={() => @count++}>{@count}</button>
+    }
+  </div>
+}`;
+        const result = await format(input, { singleQuote: true });
+        expect(result).toBe(expected);
+    });
 	});
 
 	describe('edge cases', () => {


### PR DESCRIPTION
## Summary of changes

### prettier-plugin-ripple/src/index.js
- Added `@` to tracked `Identifier` nodes

### prettier-plugin-ripple/src/index.test.js
- Added a test with multiple tracked value usages

## Testing performed
- All existing tests passed

## Any breaking changes
None 

## Related issue numbers
- Issue #271