### PR TITLE
fix: type annotation formatting to property and object patterns

### DIFF
--- a/packages/prettier-plugin-ripple/src/index.js
+++ b/packages/prettier-plugin-ripple/src/index.js
@@ -1234,6 +1234,7 @@ function printPropertyDefinition(node, path, options, print) {
 
 	// Type annotation
 	if (node.typeAnnotation) {
+		parts.push(': ');
 		parts.push(path.call(print, 'typeAnnotation'));
 	}
 
@@ -1677,6 +1678,7 @@ function printObjectPattern(node, path, options, print) {
 	parts.push(' }');
 
 	if (node.typeAnnotation) {
+		parts.push(': ');
 		parts.push(path.call(print, 'typeAnnotation'));
 	}
 

--- a/packages/prettier-plugin-ripple/src/index.test.js
+++ b/packages/prettier-plugin-ripple/src/index.test.js
@@ -342,6 +342,31 @@ export default component App() {
         const result = await format(input, { singleQuote: true });
         expect(result).toBe(expected);
     });
+
+    it('should handle type annotations in object params', async () => {
+      const input = `interface Props {
+  a: number;
+  b: string;
+}
+
+export component Test({ a, b }: Props) {}`;
+
+      const expected = `interface Props {
+  a: number;
+  b: string;
+}
+
+export component Test({ a, b }: Props) {}`;
+      const result = await format(input, { singleQuote: true });
+      expect(result).toBe(expected);
+    });
+
+    it('should handle inline type annotations in object params', async () => {
+      const input = `export component Test({ a, b}: { a: number; b: string }) {}`;
+      const expected = `export component Test({ a, b }: { a: number; b: string }) {}`;
+      const result = await format(input, { singleQuote: true });
+      expect(result).toBe(expected);
+    });
 	});
 
 	describe('edge cases', () => {


### PR DESCRIPTION
closes #280

i have never worked on a prettier plugin before, so im not sure this is the right way to handle it, but i tested it and it worked :)

