### PR TITLE
Fix unsafe nodeValue assignments in component children

### DIFF
--- a/packages/ripple/src/compiler/phases/3-transform/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/index.js
@@ -1583,13 +1583,9 @@ function transform_children(children, context) {
           if (expression.type === 'Literal') {
             state.template.push(escape_html(expression.value));
           } else {
-            const id = state.flush_node();
+            const id = flush_node();
             state.template.push(' ');
-            state.init.push(
-              b.stmt(
-                b.assignment('=', b.member(b.call('_$_.child', id), b.id('nodeValue')), expression),
-              ),
-            );
+            state.update.push(b.stmt(b.call('_$_.set_text', id, expression)));
           }
         } else {
           // Handle Text nodes in fragments


### PR DESCRIPTION
Fixes #300

Fixes runtime error `Cannot set properties of null (setting 'nodeValue')` that occurs when variable expressions are used in component children within for loops.