### PR TITLE
Fix missing graceful exit on successful project creation

### DIFF
--- a/packages/create-ripple/package.json
+++ b/packages/create-ripple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-ripple",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Interactive CLI tool for creating Ripple applications",
   "type": "module",
   "license": "MIT",

--- a/packages/create-ripple/src/commands/create.js
+++ b/packages/create-ripple/src/commands/create.js
@@ -94,6 +94,7 @@ export async function createCommand(projectName, options) {
 		});
 
 		showNextSteps(projectName, packageManager);
+		process.exit(0);
 	} catch (error) {
 		console.error(red('✖ Failed to create project:'));
 		console.error(error.message);


### PR DESCRIPTION
Add missing graceful exist once project is successfully created.