### PR TITLE
add link to llms.txt

### DIFF
--- a/website/.vitepress/config.js
+++ b/website/.vitepress/config.js
@@ -157,6 +157,7 @@ function docs_sidebar() {
 				{ text: 'Best Practices', link: 'best-practices' },
 				{ text: 'Libraries', link: 'libraries' },
 				{ text: 'Troubleshooting', link: 'troubleshooting' },
+				{ text: 'llms.txt', link: '../llms.txt',	target: '_blank' },
 			]
 		},
 	]


### PR DESCRIPTION
This PR adds a link to [llms.txt](https://www.ripplejs.com/llms.txt) in the docs sidebar for easy discoverability by humans and bots.