### PR TITLE
feat: Implement support for arrays and objects in class attribute via clsx

### DIFF
--- a/packages/ripple/package.json
+++ b/packages/ripple/package.json
@@ -66,6 +66,7 @@
     "@jridgewell/sourcemap-codec": "^1.5.5",
     "acorn": "^8.15.0",
     "acorn-typescript": "^1.4.13",
+    "clsx": "^2.1.1",
     "esrap": "^2.1.0",
     "is-reference": "^3.0.3",
     "magic-string": "^0.30.18",

--- a/packages/ripple/src/compiler/phases/3-transform/client/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/client/index.js
@@ -702,18 +702,18 @@ const visitors = {
 					const metadata = { tracking: false, await: false };
 					let expression = visit(class_attribute.value, { ...state, metadata });
 
-					if (node.metadata.scoped && state.component.css) {
-						expression = b.binary('+', expression, b.literal(' ' + state.component.css.hash));
-					}
+					const hash_arg = node.metadata.scoped && state.component.css
+						? b.literal(state.component.css.hash)
+						: undefined;
 					const is_html = context.state.metadata.namespace === 'html' && node.id.name !== 'svg';
 
 					if (metadata.tracking) {
 						local_updates.push(
-							b.stmt(b.call('_$_.set_class', id, expression, undefined, b.literal(is_html))),
+							b.stmt(b.call('_$_.set_class', id, expression, hash_arg, b.literal(is_html))),
 						);
 					} else {
 						state.init.push(
-							b.stmt(b.call('_$_.set_class', id, expression, undefined, b.literal(is_html))),
+							b.stmt(b.call('_$_.set_class', id, expression, hash_arg, b.literal(is_html))),
 						);
 					}
 				}

--- a/packages/ripple/src/runtime/internal/client/render.js
+++ b/packages/ripple/src/runtime/internal/client/render.js
@@ -15,6 +15,7 @@ import {
   is_event_attribute,
 } from '../../../utils/events.js';
 import { get } from './runtime.js';
+import { clsx } from 'clsx';
 
 /**
  * @param {Text} text
@@ -131,18 +132,17 @@ export function set_attributes(element, attributes) {
 }
 
 /**
- * @template V
- * @param {V} value
+ * @param {import('clsx').ClassValue} value
  * @param {string} [hash]
- * @returns {string | V}
+ * @returns {string}
  */
 function to_class(value, hash) {
-  return (value == null ? '' : value) + (hash ? ' ' + hash : '');
+  return value == null ? hash ?? '' : clsx([value, hash]);
 }
 
 /**
  * @param {HTMLElement} dom
- * @param {string} value
+ * @param {import('clsx').ClassValue} value
  * @param {string} [hash]
  * @param {boolean} [is_html]
  * @returns {void}

--- a/packages/ripple/src/runtime/internal/server/index.js
+++ b/packages/ripple/src/runtime/internal/server/index.js
@@ -6,6 +6,8 @@ import { is_tracked_object } from '../client/utils';
 import { escape } from '../../../utils/escaping.js';
 import { is_boolean_attribute } from '../../../compiler/utils';
 
+import { clsx } from 'clsx';
+
 export { escape };
 
 /** @type {Component | null} */
@@ -132,7 +134,8 @@ export function attr(name, value, is_boolean = false) {
 	}
 	if (value == null || (!value && is_boolean)) return '';
 	const normalized = (name in replacements && replacements[name].get(value)) || value;
-	const assignment = is_boolean ? '' : `="${escape(normalized, true)}"`;
+	const value_to_escape = name === 'class' ? clsx(normalized) : normalized;
+	const assignment = is_boolean ? '' : `="${escape(value_to_escape, true)}"`;
 	return ` ${name}${assignment}`;
 }
 
@@ -155,7 +158,7 @@ export function spread_attrs(attrs, css_hash) {
     }
 
     if (name === 'class' && css_hash) {
-      value = (value == null ? '' : value) + ' ' + css_hash;
+      value = value == null ? css_hash : [value, css_hash];
     }
 
 		attr_str += attr(name, value, is_boolean_attribute(name));

--- a/packages/ripple/tests/client/basic.test.ripple
+++ b/packages/ripple/tests/client/basic.test.ripple
@@ -142,6 +142,81 @@ describe('basic client', () => {
 		expect(div.classList.contains('inactive')).toBe(true);
 	});
 
+	it('render class attribute with array, nested array, nested object', () => {
+		component Basic() {
+			<div class={[
+				'foo',
+				'bar',
+				true && 'baz',
+				false && 'aaa',
+				null && 'bbb',
+				[
+					'ccc',
+					'ddd',
+					{ eee: true, fff: false }
+				]
+			]}>
+				{'Class Array'}
+			</div>
+
+			<style>
+				.foo {
+				  color: red;
+				}
+			</style>
+		}
+
+		render(Basic);
+
+		const div = container.querySelector('div');
+
+		expect(Array.from(div.classList).some(className => className.startsWith('ripple-'))).toBe(true);
+		expect(div.classList.contains('foo')).toBe(true);
+		expect(div.classList.contains('bar')).toBe(true);
+		expect(div.classList.contains('baz')).toBe(true);
+		expect(div.classList.contains('aaa')).toBe(false);
+		expect(div.classList.contains('bbb')).toBe(false);
+		expect(div.classList.contains('ccc')).toBe(true);
+		expect(div.classList.contains('ddd')).toBe(true);
+		expect(div.classList.contains('eee')).toBe(true);
+		expect(div.classList.contains('fff')).toBe(false);
+	});
+
+	it('render dynamic class object', () => {
+		component Basic() {
+			let active = track(false);
+
+			<button onClick={() => { @active = !@active }}>{'Toggle'}</button>
+			<div class={{ active: @active, inactive: !@active }}>{'Dynamic Class'}</div>
+
+			<style>
+				.active {
+					color: green;
+				}
+			</style>
+		}
+
+		render(Basic);
+
+		const button = container.querySelector('button');
+		const div = container.querySelector('div');
+
+		expect(Array.from(div.classList).some(className => className.startsWith('ripple-'))).toBe(true);
+		expect(div.classList.contains('inactive')).toBe(true);
+		expect(div.classList.contains('active')).toBe(false);
+
+		button.click();
+		flushSync();
+		expect(div.classList.contains('inactive')).toBe(false);
+		expect(div.classList.contains('active')).toBe(true);
+
+		button.click();
+		flushSync();
+
+		expect(div.classList.contains('inactive')).toBe(true);
+		expect(div.classList.contains('active')).toBe(false);
+	});
+
 	it('render dynamic id attribute', () => {
 		component Basic() {
 			let count = track(0);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       acorn-typescript:
         specifier: ^1.4.13
         version: 1.4.13(acorn@8.15.0)
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       esrap:
         specifier: ^2.1.0
         version: 2.1.0
@@ -1058,6 +1061,10 @@ packages:
 
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
   comma-separated-tokens@2.0.3:
@@ -2683,6 +2690,8 @@ snapshots:
       restore-cursor: 5.1.0
 
   cli-spinners@2.9.2: {}
+
+  clsx@2.1.1: {}
 
   comma-separated-tokens@2.0.3: {}
 


### PR DESCRIPTION
Closes #322.

## What it does
This PR adds the ability to specify arrays and objects in the class attribute via the tiny clsx library as suggested in the mentioned issue. For example:

```jsx
<div class={[
  'hello',
  'world',
  isActive && 'active',
  ['nested', 'array'],
  {
    foo: isFoo,
    bar: isBar,
  },
]}>
  {`This is an example`}
</div>
```

## Testing
I added two new tests for the new functionality. Then I ran all tests:
```bash
pnpm test
```
All tests, including the two new ones I added, passed successfully. As far a I understand, no breaking changes here, `<div class="hello world" />` works like before.