### PR TITLE
fix: documentation quickstart

### DIFF
--- a/website/docs/quick-start.md
+++ b/website/docs/quick-start.md
@@ -12,7 +12,7 @@ You can try Ripple directly in your browser on [StackBlitz](https://stackblitz.c
 ### Using The <Badge type="warning" text="Experimental" /> `create-ripple` CLI
 
 ```sh
-npm create ripple // [!=npm auto]
+npx create-ripple // [!=npm auto]
 ```
 
 ### Clone the Vite-based Basic Template:


### PR DESCRIPTION
Fixed documentation quickstart guide to properly follow the create-ripple logic.