### PR TITLE
fix: path issues in create-ripple scaffolding

### DIFF
--- a/packages/create-ripple/src/lib/project-creator.js
+++ b/packages/create-ripple/src/lib/project-creator.js
@@ -215,7 +215,7 @@ export default {
 `;
 		writeFileSync(join(projectPath, 'tailwind.config.ts'), tailwindConfig);
 		const mainCss = `@import "tailwindcss";
-@config "./tailwind.config.ts";`;
+@config "../tailwind.config.ts";`;
 		writeFileSync(join(projectPath, 'src', 'index.css'), mainCss);
 
 		const mainTs = readFileSync(join(projectPath, 'src', 'index.ts'), 'utf-8');


### PR DESCRIPTION
This PR resolves the issue of path being not found for tailwind.config.ts file in create-ripple package