### PR TITLE
fix: output bloated when on passed tests in create-ripple

### DIFF
--- a/packages/create-ripple/package.json
+++ b/packages/create-ripple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-ripple",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Interactive CLI tool for creating Ripple applications",
   "type": "module",
   "license": "MIT",

--- a/packages/create-ripple/vitest.config.js
+++ b/packages/create-ripple/vitest.config.js
@@ -5,6 +5,8 @@ export default defineConfig({
 		include: ['tests/**/*.test.js'],
 		environment: 'node',
 		globals: true,
+		silent: 'passed-only',
+		reporter: 'verbose',
 		coverage: {
 			provider: 'v8',
 			reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
Added silent mode for passing tests in the create-ripple package.
Also bumped version.