### PR TITLE
perf: Speedup CSS property normalization by not using .has()

### DIFF
--- a/packages/ripple/src/utils/normalize_css_property_name.js
+++ b/packages/ripple/src/utils/normalize_css_property_name.js
@@ -10,10 +10,13 @@ const normalized_properties_cache = new Map();
  */
 export function normalize_css_property_name(str) {
 	if (str.startsWith('--')) return str;
-	if (normalized_properties_cache.has(str)) {
-		return /** @type {string} */ (normalized_properties_cache.get(str));
+
+	let normalized_result = normalized_properties_cache.get(str);
+	if (normalized_result != null) {
+		return normalized_result;
 	}
-	const normalized_result = str.replace(/[A-Z]/g, m => '-' + m.toLowerCase());
+
+	normalized_result = str.replace(/[A-Z]/g, m => '-' + m.toLowerCase());
 	normalized_properties_cache.set(str, normalized_result);
 
 	return normalized_result;


### PR DESCRIPTION
This is a followup PR to #362. It removes using `.has()`, using `.get()` directly instead. According to tests I've done, it yields 10 to 15% performance improvement in both Chrome and Firefox. Behavior stays the same, the tests still pass after this change.

Thanks to @leonidaz for the [comment](https://github.com/trueadm/ripple/pull/362#discussion_r2387509480)