### PR TITLE
misc ci changes

### DIFF
--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -9,6 +9,8 @@ on:
 permissions:
     contents: read
 
+name: Check for NPM Provenance Downgrade
+
 jobs:
     check-provenance:
         runs-on: ubuntu-latest

--- a/.github/workflows/vsix.yml
+++ b/.github/workflows/vsix.yml
@@ -10,6 +10,8 @@ jobs:
     version-check:
         name: "Verify version change"
         runs-on: ubuntu-latest
+        outputs:
+            version-changed: ${{ steps.compare_versions.outputs.result }}
 
         steps:
             - name: Checkout Code
@@ -30,13 +32,15 @@ jobs:
 
                   if [ "${CURRENT_VERSION}" == "${PREVIOUS_VERSION}" ]; then
                     echo "::warn::Version number not changed, skipping publish..."
-                    exit 1
+                    echo "changed=false" >> "$GITHUB_OUTPUT"
                   else
                     echo "Version was changed: ${PREVIOUS_VERSION} -> ${CURRENT_VERSION}"
+                    echo "changed=true" >> "$GITHUB_OUTPUT"
                   fi
 
     build:
         needs: version-check
+        if: needs.version-check.outputs.changed == "true"
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code


### PR DESCRIPTION
- prevent vsc ext auto-publish from turning ci red if version remained same
- gave provenance downgrade check a name so it looks nice on github