### PR TITLE
test: Add test for mutating tracked value inside computed track() evaluation

### DIFF
--- a/packages/ripple/tests/client/basic.test.ripple
+++ b/packages/ripple/tests/client/basic.test.ripple
@@ -1760,5 +1760,46 @@ describe('basic client', () => {
 		await promise; 
 		expect(p.textContent).toBe('1');
 	});
+
+	it('errors on mutating tracked value inside computed track() evaluation', () => {
+		component Basic() {
+			let count = track(0);
+
+			let p = track();
+			function pRef(node) {
+				@p = node;
+
+				return () => {
+					@p = null;
+				};
+			}
+
+			const doubled = track(() => {
+				try {
+					@count *= 2;
+				} catch (e) {
+					if(@p) {
+						@p.textContent = e.message;
+					}
+				}
+			});
+
+			<p class='error' {ref pRef} />
+
+			<p>{@doubled}</p>
+
+			<button onClick={() => { @count++; }}>{@count}</button>
+		}
+
+		render(Basic);
+
+		const button = container.querySelector('button');
+		const error = container.querySelector('.error');
+
+		button.click();
+		flushSync();
+
+		expect(error.textContent).toContain('Assignments or updates to tracked values are not allowed during computed "track(() => ...)" evaluation');
+	});
 });
 

--- a/packages/ripple/tests/client/basic.test.ripple
+++ b/packages/ripple/tests/client/basic.test.ripple
@@ -5,6 +5,7 @@ import { TRACKED_ARRAY } from '../../src/runtime/internal/client/constants.js';
 
 describe('basic client', () => {
 	let container;
+	let error;
 
 	function render(component) {
 		mount(component, {
@@ -15,11 +16,13 @@ describe('basic client', () => {
 	beforeEach(() => {
 		container = document.createElement('div');
 		document.body.appendChild(container);
+		error = undefined;
 	});
 
 	afterEach(() => {
 		document.body.removeChild(container);
 		container = null;
+		error = undefined;
 	});
 
 	it('render static text', () => {
@@ -1422,7 +1425,7 @@ describe('basic client', () => {
 		flushSync();
 		expect(countSpan.textContent).toBe('1');
 	});
-  
+
 	it('handles boolean attributes with no prop value provides', () => {
 		component App() {
 			<div class="container">
@@ -1757,7 +1760,7 @@ describe('basic client', () => {
 
 		const p = container.querySelector('p');
 		expect(p.textContent).toBe('0');
-		await promise; 
+		await promise;
 		expect(p.textContent).toBe('1');
 	});
 
@@ -1765,41 +1768,80 @@ describe('basic client', () => {
 		component Basic() {
 			let count = track(0);
 
-			let p = track();
-			function pRef(node) {
-				@p = node;
-
-				return () => {
-					@p = null;
-				};
-			}
-
 			const doubled = track(() => {
 				try {
 					@count *= 2;
 				} catch (e) {
-					if(@p) {
-						@p.textContent = e.message;
-					}
+					error = e.message;
 				}
 			});
 
-			<p class='error' {ref pRef} />
-
 			<p>{@doubled}</p>
-
-			<button onClick={() => { @count++; }}>{@count}</button>
 		}
 
 		render(Basic);
 
-		const button = container.querySelector('button');
-		const error = container.querySelector('.error');
+		expect(error).toBe('Assignments or updates to tracked values are not allowed during computed "track(() => ...)" evaluation');
+	});
 
-		button.click();
-		flushSync();
+	it('errors on mutating tracked value inside untrack() in computed track() evaluation', () => {
+		component Basic() {
+			let count = track(0);
 
-		expect(error.textContent).toContain('Assignments or updates to tracked values are not allowed during computed "track(() => ...)" evaluation');
+			const doubled = track(() => {
+				try {
+					untrack(() => {
+						@count *= 2;
+					});
+				} catch (e) {
+					error = e.message;
+				}
+			});
+
+			<p>{@doubled}</p>
+		}
+
+		render(Basic);
+
+		expect(error).toBe('Assignments or updates to tracked values are not allowed during computed "track(() => ...)" evaluation');
+	});
+
+	it("errors on mutating a tracked variable in track() getter", () => {
+		component Basic() {
+			let count = track(0);
+
+			const doubled = track(0, (value) => {
+				try {
+					@count += 1;
+				} catch (e) {
+					error = e.message;
+				}
+				return value;
+			});
+
+			<p>{@doubled}</p>
+		}
+
+		render(Basic);
+
+		expect(error).toBe('Assignments or updates to tracked values are not allowed during computed "track(() => ...)" evaluation');
+	});
+
+	it("doesn't error on mutating a tracked variable in track() setter", () => {
+		component Basic() {
+			let count = track(0);
+
+			const doubled = track(0, undefined, (value) => {
+				@count += value;
+				return value;
+			});
+
+			<p>{@doubled}</p>
+		}
+
+		render(Basic);
+
+		expect(error).toBe(undefined);
 	});
 });
 


### PR DESCRIPTION
A recent commit disallowed mutating tracked values inside computed `track()`. This test tries to mutate a tracked value inside a computed `track()`, and verifies that the error gets thrown.

Side note: is there a better way to catch errors and get their text in the test? This is the only solution I came up with that seemed to work.