### PR TITLE
change createContext to new Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -924,18 +924,20 @@ Both examples above will render the same inline styles, however, it's recommende
 ### Context
 
 Ripple has the concept of `context` where a value or reactive object can be shared through the component tree –
-like in other frameworks. This all happens from the `createContext` function that is imported from `ripple`.
+like in other frameworks. This all happens from the `Context` class that is imported from `ripple`.
 
 Creating contexts may take place anywhere. Contexts can contain anything including tracked values or objects. However, context cannot be read via `get` or written to via `set` inside an event handler or at the module level as it must happen within the context of a component. A good strategy is to assign the contents of a context to a variable via the `.get()` method during the component initialization and use this variable for reading and writing.
+
+When Child components overwrite a context's value via `.set()`, this new value will only be seen by its descendants. Components higher up in the tree will continue to see the original value.
 
 Example with tracked / reactive contents:
 
 ```jsx
-import { track, createContext } from "ripple"
+import { track, Context } from "ripple"
 
 // create context with an empty object
-const context  = createContext({});
-const context2 = createContext();
+const context  = new Context({});
+const context2 = new Context();
 
 export component App() {
   // get reference to the object
@@ -963,9 +965,9 @@ export component App() {
 Passing data between components:
 
 ```jsx
-import { createContext } from 'ripple';
+import { Context } from 'ripple';
 
-const MyContext = createContext(null);
+const MyContext = new Context(null);
 
 component Child() {
   // Context is read in the Child component
@@ -993,9 +995,9 @@ component Parent() {
 You can also pass a reactive `Tracked<V>` object through context and read it at the other side.
 
 ```jsx
-import { createContext, effect } from 'ripple';
+import { Context, effect } from 'ripple';
 
-const MyContext = createContext(null);
+const MyContext = new Context(null);
 
 component Child() {
   const count = MyContext.get();

--- a/packages/prettier-plugin-ripple/src/index.test.js
+++ b/packages/prettier-plugin-ripple/src/index.test.js
@@ -59,7 +59,7 @@ describe('prettier-plugin-ripple', () => {
         <div>{"Hello"}</div>
         <div>
           let two=2
-          
+
           {"Hello"}
         </div>
     }`;
@@ -92,7 +92,7 @@ describe('prettier-plugin-ripple', () => {
             }
 
             if (y) {
-            
+
               return null;
 
             }
@@ -104,7 +104,7 @@ describe('prettier-plugin-ripple', () => {
         <div>{"Hello"}</div>
         <div>
           let two=2
-          
+
           {"Hello"}
         </div>
     }`;
@@ -511,7 +511,7 @@ message.push(/* Some test comment */ greet(/* Some text */ \`Ripple\`));`;
 
   it('should handle different attribute value types correctly', async () => {
     const input = `export component Test() {
-  <div 
+  <div
     stringProp="hello"
     numberProp={42}
     booleanProp={true}
@@ -557,10 +557,10 @@ for (const { i = 0, item } of items.entries()) {}`;
   });
 
   it('should handle various other TS things', async () => {
-    const input = `const globalContext = createContext<{ theme: string, array: number[] }>({ theme: 'light', array: [] });
+    const input = `const globalContext = new Context<{ theme: string, array: number[] }>({ theme: 'light', array: [] });
 const items = [] as unknown[];`
 
-    const expected = `const globalContext = createContext<{ theme: string; array: number[] }>({
+    const expected = `const globalContext = new Context<{ theme: string; array: number[] }>({
   theme: "light",
   array: [],
 });

--- a/packages/ripple/src/runtime/index-client.js
+++ b/packages/ripple/src/runtime/index-client.js
@@ -40,7 +40,7 @@ export function mount(component, options) {
 	};
 }
 
-export { create_context as createContext } from './internal/client/context.js';
+export { Context } from './internal/client/context.js';
 
 export {
 	flush_sync as flushSync,

--- a/packages/ripple/src/runtime/index-server.js
+++ b/packages/ripple/src/runtime/index-server.js
@@ -4,7 +4,7 @@ import { DERIVED, TRACKED, UNINITIALIZED } from './internal/client/constants.js'
 import { is_tracked_object } from './internal/client/utils.js';
 import { active_component } from './internal/server/index.js';
 
-export { create_context as createContext } from './internal/server/context.js';
+export { Context } from './internal/server/context.js';
 
 export function effect() {
 	// NO-OP
@@ -44,4 +44,3 @@ export function track(v, get, set) {
 		v,
 	};
 }
-

--- a/packages/ripple/src/runtime/internal/client/context.js
+++ b/packages/ripple/src/runtime/internal/client/context.js
@@ -58,12 +58,3 @@ export class Context {
     current_context.set(context, value);
   }
 }
-
-/**
- * @template T
- * @param {T} initial_value
- * @returns {Context<T>}
- */
-export function create_context(initial_value) {
-  return new Context(initial_value);
-}

--- a/packages/ripple/src/runtime/internal/server/context.js
+++ b/packages/ripple/src/runtime/internal/server/context.js
@@ -58,12 +58,3 @@ export class Context {
     current_context.set(context, value);
   }
 }
-
-/**
- * @template T
- * @param {T} initial_value
- * @returns {Context<T>}
- */
-export function create_context(initial_value) {
-  return new Context(initial_value);
-}

--- a/packages/ripple/tests/client/context.test.ripple
+++ b/packages/ripple/tests/client/context.test.ripple
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mount, createContext, flushSync, track } from 'ripple';
+import { mount, Context, flushSync, track } from 'ripple';
 
 describe('context', () => {
 	let container;
@@ -20,7 +20,7 @@ describe('context', () => {
 	});
 
 	it('creates a reactive ref with initial value', () => {
-		const MyContext = createContext(null);
+		const MyContext = new Context(null);
 
 		component Child() {
 			const value = MyContext.get();
@@ -42,8 +42,8 @@ describe('context', () => {
 	});
 
 	it('handles context captured inside a computed tracked', () => {
-		
-		const MyContext = createContext(null)
+
+		const MyContext = new Context(null)
 
 		const doubleContext = () => {
 			const value = MyContext.get()
@@ -52,7 +52,7 @@ describe('context', () => {
 
 		component App() {
 			MyContext.set(4)
-				
+
 			<h3>{MyContext.get()}</h3>
 
 			<h4>{'2x:'} {doubleContext()}</h4>

--- a/packages/ripple/types/index.d.ts
+++ b/packages/ripple/types/index.d.ts
@@ -24,12 +24,12 @@ export interface TrackedArray<T> extends Array<T> { }
 
 export declare const TrackedArray: TrackedArrayConstructor;
 
-export type Context<T> = {
-	get(): T;
-	set(value: T): void;
-};
-
-export declare function createContext<T>(initialValue: T): Context<T>;
+export declare class Context<T> {
+	constructor(initial_value: T);
+  get(): T;
+  set(value: T): void;
+	#private;
+}
 
 export declare class TrackedSet<T> extends Set<T> {
 	isDisjointFrom(other: TrackedSet<T> | Set<T>): boolean;

--- a/website/docs/examples.ts
+++ b/website/docs/examples.ts
@@ -649,9 +649,9 @@ export default component App() {
 	},
 	{
 		title: 'Context',
-		code: `import { createContext } from 'ripple';
+		code: `import { Context } from 'ripple';
 
-const MyContext = createContext(null);
+const MyContext = new Context(null);
 
 export default component Parent() {
 	const value = MyContext.get();

--- a/website/docs/guide/state-management.md
+++ b/website/docs/guide/state-management.md
@@ -8,40 +8,86 @@ title: State management in Ripple
 
 Ripple has the concept of `context` where a value or reactive object can be
 shared through the component tree – like in other frameworks. This all happens
-from the `createContext` function that is imported from `ripple`.
+from the `Context` class that is imported from `ripple`.
 
-When you create a context, you can `get` and `set` the values, but this must
-happen within the context of a component (they can physically live anywhwere,
-they just need to be called from a component context). Using them outside will
-result in an error being thrown.
+Creating contexts may take place anywhere. Contexts can contain anything
+including tracked values or objects. However, context cannot be read via `get`
+or written to via `set` inside an event handler or at the module level as it
+must happen within the context of a component. A good strategy is to assign
+the contents of a context to a variable via the `.get()` method during the
+component initialization and use this variable for reading and writing.
 
-<Code console>
+When Child components overwrite a context's value via `.set()`, this new
+value will only be seen by its descendants. Components higher up in the tree
+will continue to see the original value.
+
+Example with tracked / reactive contents:
+
+<Code>
 
 ```ripple
-import { createContext } from 'ripple';
+import { track, Context } from "ripple"
 
-const MyContext = createContext(null);
+// create context with an empty object
+const context  = new Context({});
+const context2 = new Context();
 
-component Parent() {
-	const value = MyContext.get();
+export component App() {
+  // get reference to the object
+  const obj = context.get();
+  // set your reactive value
+  obj.count = track(0);
 
-	// Context is read in the Parent component, but hasn't yet
-	// been set, so we fallback to the initial context value.
-	// So the value is `null`
-	console.log(value);
+  // create another tracked variable
+  const count2 = track(0);
+  // context2 now contains a trackrf variable
+  context2.set(count2);
 
-	// Context is set in the Parent component
-	MyContext.set("Hello from context!");
+  <button onClick={() => { obj.@count++; @count2++ }}>
+    {'Click Me'}
+  </button>
 
-	<Child />
+  // context's reactive property count gets updated
+  <pre>{'Context: '}{context.get().@count}</pre>
+  <pre>{'Context2: '}{@count2}</pre>
 }
+```
+
+</Code>
+
+::: info
+`@(context2.get())` usage with `@()` wrapping syntax will be enabled in the near future
+:::
+
+Passing data between components:
+
+<Code>
+
+```ripple
+import { Context } from 'ripple';
+
+const MyContext = new Context(null);
 
 component Child() {
-	// Context is read in the Child component
-	const value = MyContext.get();
+  // Context is read in the Child component
+  const value = MyContext.get();
 
-	// value is "Hello from context!"
-	console.log(value);
+  // value is "Hello from context!"
+  console.log(value);
+}
+
+component Parent() {
+  const value = MyContext.get();
+
+  // Context is read in the Parent component, but hasn't yet
+  // been set, so we fallback to the initial context value.
+  // So the value is `null`
+  console.log(value);
+
+  // Context is set in the Parent component
+  MyContext.set("Hello from context!");
+
+  <Child />
 }
 ```
 

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -575,7 +575,7 @@ import {
   untrack,         // Prevent reactivity tracking
   flushSync,       // Synchronous state updates
   effect,          // Side effects
-  createContext    // Context API
+  Context          // Context API
 } from 'ripple';
 ```
 
@@ -630,18 +630,72 @@ export component App() {
 ```
 
 ### Context
-```ripple
-import { createContext } from 'ripple';
 
-const ThemeContext = createContext('light');
+Ripple has the concept of `context` where a value or reactive object can be shared through the component tree –
+like in other frameworks. This all happens from the `Context` class that is imported from `ripple`.
+
+Creating contexts may take place anywhere. Contexts can contain anything including tracked values or objects. However, context cannot be read via `get` or written to via `set` inside an event handler or at the module level as it must happen within the context of a component. A good strategy is to assign the contents of a context to a variable via the `.get()` method during the component initialization and use this variable for reading and writing.
+
+When Child components overwrite a context's value via `.set()`, this new value will only be seen by its descendants. Components higher up in the tree will continue to see the original value.
+
+Example with tracked / reactive contents:
+
+```ripple
+import { track, Context } from "ripple"
+
+// create context with an empty object
+const context  = new Context({});
+const context2 = new Context();
+
+export component App() {
+  // get reference to the object
+  const obj = context.get();
+  // set your reactive value
+  obj.count = track(0);
+
+  // create another tracked variable
+  const count2 = track(0);
+  // context2 now contains a trackrf variable
+  context2.set(count2);
+
+  <button onClick={() => { obj.@count++; @count2++ }}>
+    {'Click Me'}
+  </button>
+
+  // context's reactive property count gets updated
+  <pre>{'Context: '}{context.get().@count}</pre>
+  <pre>{'Context2: '}{@count2}</pre>
+}
+```
+
+> Note: `@(context2.get())` usage with `@()` wrapping syntax will be enabled in the near future
+
+Passing data between components:
+
+```ripple
+import { Context } from 'ripple';
+
+const MyContext = new Context(null);
 
 component Child() {
-  const theme = ThemeContext.get();
-  <div class={theme}>{"Themed content"}</div>
+  // Context is read in the Child component
+  const value = MyContext.get();
+
+  // value is "Hello from context!"
+  console.log(value);
 }
 
 component Parent() {
-  ThemeContext.set('dark');
+  const value = MyContext.get();
+
+  // Context is read in the Parent component, but hasn't yet
+  // been set, so we fallback to the initial context value.
+  // So the value is `null`
+  console.log(value);
+
+  // Context is set in the Parent component
+  MyContext.set("Hello from context!");
+
   <Child />
 }
 ```
@@ -874,7 +928,7 @@ component MyComponent(props: Props) {
 ### Context Types
 ```typescript
 type Theme = 'light' | 'dark';
-const ThemeContext = createContext<Theme>('light');
+const ThemeContext = new Context<Theme>('light');
 ```
 
 ## File Structure


### PR DESCRIPTION
- changes syntax for `createContext()` to use `new Context()`.
- clarity that it's not just a global context that is being created and multiple ones can exist
- move away from the React association with useContext, creating provider, etc.