### PR TITLE
playground styles

### DIFF
--- a/website/.vitepress/components/LiveCodes.vue
+++ b/website/.vitepress/components/LiveCodes.vue
@@ -262,11 +262,13 @@ const copyUrl = async () => {
 const getPlaygroundStyle = () => ({
 	height:
 		props.height ??
-		(props.isMainPlayground ? 'calc(100dvh - 113px)' : undefined),
+		(props.isMainPlayground ? 'calc(100dvh - 110px)' : undefined),
 	minHeight: props.isMainPlayground ? '400px' : undefined,
 	marginTop: props.isMainPlayground ? '1.5rem' : undefined,
 	borderRadius: props.isMainPlayground ? undefined : '8px',
-	border: `1px solid ${isDark.value ? '#333' : '#ddd'}`,
+	border: props.isMainPlayground
+		? undefined
+		: `1px solid ${isDark.value ? '#333' : '#ddd'}`,
 })
 const playgroundStyle = ref(getPlaygroundStyle())
 

--- a/website/.vitepress/theme/styles.css
+++ b/website/.vitepress/theme/styles.css
@@ -43,7 +43,7 @@
 }
 
 div.VPContent {
-	margin-top: -5px !important;
+	margin-top: -7px !important;
 }
 
 /* Playground */
@@ -75,5 +75,5 @@ body:has(.main-playground) .VPFooter {
 }
 
 .main-playground .VPMenu {
-	max-height: calc(100dvh - 113px);
+	max-height: calc(100dvh - 110px);
 }


### PR DESCRIPTION
This is a follow up PR for #383 

Just small style improvements:
- It removes the main playground border to avoid having double borders (with header) while loading
- better vertical alignment of playground buttons