### PR TITLE
Added ripple icon entry in contributes schema for both light & dark mode

### DIFF
--- a/packages/ripple-vscode-plugin/package.json
+++ b/packages/ripple-vscode-plugin/package.json
@@ -41,6 +41,10 @@
         "extensions": [
           ".ripple"
         ],
+        "icon": {
+          "light": "icons/logo.png",
+          "dark": "icons/logo.png"
+        },
         "configuration": "./language-configuration.json"
       }
     ],


### PR DESCRIPTION
Hi, 
I saw while playing around with ripple that no logo is shown for .ripple files. So I thought of adding this for both light and dark mode. 
Maybe we can later decided separate icons for both modes. 

I'm not sure whether I should package the extension again or not and update that too with in this PR. 

It will be a huge help if someone can guide a little on what else I should do to get this PR merged.

P.S: This is my first PR to any library :)

<img width="706" height="276" alt="Screenshot 2025-10-02 at 4 55 01 AM" src="https://github.com/user-attachments/assets/b95aeba3-884c-4181-80dd-3839c025362d" />
