### PR TITLE
Preserve default playground URL

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,8 +228,8 @@ importers:
   website:
     dependencies:
       livecodes:
-        specifier: 0.11.1
-        version: 0.11.1
+        specifier: 0.12.0
+        version: 0.12.0
     devDependencies:
       vitepress:
         specifier: 2.0.0-alpha.12
@@ -1393,8 +1393,8 @@ packages:
     resolution: {integrity: sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==}
     engines: {node: '>= 12.0.0'}
 
-  livecodes@0.11.1:
-    resolution: {integrity: sha512-v+TF4pD4wVk+7jYV7WD+PGMxU/zWlATZ80Y7ze6gAgPCJMdWNwbz5Y16+BSbwmfPjFeyMTSGWSYuiCEwEBkSzw==}
+  livecodes@0.12.0:
+    resolution: {integrity: sha512-qDK12wLThvdfAoDLyCDSn7hQ6Ii7/BkG8YQOlYuM5LjxOSNkJvh9F2Lm6BOS0dNy2uBXRSvWm3XAph3QgBdlOw==}
 
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
@@ -2996,7 +2996,7 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.30.1
       lightningcss-win32-x64-msvc: 1.30.1
 
-  livecodes@0.11.1: {}
+  livecodes@0.12.0: {}
 
   log-symbols@6.0.0:
     dependencies:

--- a/website/.vitepress/components/LiveCodes.vue
+++ b/website/.vitepress/components/LiveCodes.vue
@@ -42,7 +42,7 @@ const themeColor =
 		.getPropertyValue('--vp-c-brand-3') || '#2d6dbf'
 let playground: Playground | undefined
 const playgroundActions = useTemplateRef('playground-actions')
-const title = ref('')
+const title = ref(props.code ? undefined : 'Counter')
 const tailwind = ref(false)
 const vim = ref(getUserSettings().vim ?? false)
 const ai = ref(getUserSettings().ai !== false)
@@ -111,7 +111,7 @@ const getStyle = () => ({
 })
 
 const config: Partial<Config> = {
-	title: props.code ? undefined : 'Counter',
+	title: title.value,
 	customSettings: { ripple: { version: version.value } },
 	view: props.view ?? 'split',
 	mode: props.mode ?? 'full',
@@ -163,7 +163,12 @@ const onReady = (sdk: Playground) => {
 
 	// sync the UI with config from  shared URL
 	playground.getConfig().then((config) => {
-		if (config.title?.trim() && config.title !== 'Untitled Project') {
+		console.log(config.title, title.value)
+		if (
+			config.title?.trim() &&
+			config.title !== 'Untitled Project' &&
+			config.title !== title.value
+		) {
 			title.value = config.title
 		}
 

--- a/website/.vitepress/components/LiveCodes.vue
+++ b/website/.vitepress/components/LiveCodes.vue
@@ -135,7 +135,7 @@ const config: Partial<Config> = {
 }
 
 const options: EmbedOptions = {
-	appUrl: hash ? `${playgroundUrl}${hash.replace('#', '?')}` : playgroundUrl,
+	appUrl: playgroundUrl + (hash || ''),
 	loading: 'eager',
 	config: hash ? undefined : config,
 }

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,7 @@
 	"license": "MIT",
 	"packageManager": "pnpm@10.14.0",
 	"dependencies": {
-		"livecodes": "0.11.1"
+		"livecodes": "0.12.0"
 	},
 	"devDependencies": {
 		"vitepress": "2.0.0-alpha.12",


### PR DESCRIPTION
This PR preserves the default playground URL and avoids changing it to a share URL on load.
In addition, the LiveCodes SDK was updated, which adds `ripple` as a valid language name (to remove the TS error), and has some other fixes.