### PR TITLE
Extract LSP from VS Code extension

### DIFF
--- a/packages/ripple-language-server/LICENSE
+++ b/packages/ripple-language-server/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Dominic Gannaway
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/ripple-language-server/README.md
+++ b/packages/ripple-language-server/README.md
@@ -1,0 +1,43 @@
+# ripple-language-server
+
+Language Server Protocol (LSP) implementation for Ripple. This package provides language intelligence features for
+Ripple files and can be integrated into any editor that supports LSP.
+
+## Features
+
+- TypeScript integration via Volar
+- Ripple syntax diagnostics
+- IntelliSense and autocomplete
+- Go to definition
+- Find references
+- Hover information
+
+## Installation
+
+```bash
+npm install ripple-language-server -g
+```
+
+### Editor Integration
+
+This language server can be integrated into any editor that supports LSP:
+
+#### VS Code
+
+Use the [official extension](https://marketplace.visualstudio.com/items?itemName=ripplejs.ripple-vscode-plugin) instead.
+It uses this language server internally.
+
+#### WebStorm/IntelliJ
+
+1. Install the [LSP4IJ plugin](https://plugins.jetbrains.com/plugin/23257-lsp4ij).
+2. Add a new language server in it
+3. Specify `ripple-language-server --stdio` as the command in it.
+4. Go to `Mappings` —> `File name patterns` and add a new value with `File name patterns` set to `*.ripple` and `Language Id` set to `ripple.
+
+#### Neovim
+
+TODO Write instructions
+
+#### Sublime Text
+
+TODO Write instructions

--- a/packages/ripple-language-server/bin/ripple-language-server.js
+++ b/packages/ripple-language-server/bin/ripple-language-server.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+const { createRippleLanguageServer } = require('../src/server.js');
+
+createRippleLanguageServer();
+

--- a/packages/ripple-language-server/index.js
+++ b/packages/ripple-language-server/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./src/server');

--- a/packages/ripple-language-server/package.json
+++ b/packages/ripple-language-server/package.json
@@ -16,10 +16,10 @@
   "dependencies": {
     "@volar/language-server": "~2.4.23",
     "typescript-plugin-ripple": "workspace:*",
+    "volar-service-typescript": "0.0.65",
     "vscode-uri": "^3.1.0"
   },
   "peerDependencies": {
     "typescript": ">=5.0.0"
   }
 }
-

--- a/packages/ripple-language-server/package.json
+++ b/packages/ripple-language-server/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "ripple-language-server",
+  "version": "0.0.1",
+  "description": "Language Server Protocol implementation for Ripple",
+  "main": "index.js",
+  "bin": {
+    "ripple-language-server": "bin/ripple-language-server.js"
+  },
+  "author": "Dominic Gannaway",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/trueadm/ripple.git",
+    "directory": "packages/ripple-language-server"
+  },
+  "dependencies": {
+    "@volar/language-server": "~2.4.23",
+    "typescript-plugin-ripple": "workspace:*",
+    "vscode-uri": "^3.1.0"
+  },
+  "peerDependencies": {
+    "typescript": ">=5.0.0"
+  }
+}
+

--- a/packages/ripple-language-server/src/diagnosticPlugin.js
+++ b/packages/ripple-language-server/src/diagnosticPlugin.js
@@ -122,11 +122,10 @@ function parseCompilationErrorWithDocument(error, fallbackFileName, sourceText, 
 
 			// Convert 1-based line/column to 0-based for VS Code
 			const zeroBasedLine = Math.max(0, line - 1);
-			const zeroBasedColumn = Math.max(0, column - 1);
+			const actualColumn = Math.max(0, column - 1);
 
 			// Use the original error coordinates from the Ripple compiler
 			// Just use the compiler's position as-is, with a simple 1-character highlight
-			let actualColumn = zeroBasedColumn;
 			let length = Math.min(1, sourceText.split('\n')[zeroBasedLine]?.length - actualColumn || 1);
 
 			return {
@@ -204,3 +203,4 @@ function getEmbeddedInfo(context, document) {
 module.exports = {
 	createRippleDiagnosticPlugin,
 };
+

--- a/packages/ripple-language-server/src/server.js
+++ b/packages/ripple-language-server/src/server.js
@@ -1,10 +1,11 @@
 ﻿const {
 	createConnection,
 	createServer,
-	createSimpleProject,
+	createTypeScriptProject,
 } = require('@volar/language-server/node');
 const { createRippleDiagnosticPlugin } = require('./diagnosticPlugin.js');
 const { getRippleLanguagePlugin } = require('typescript-plugin-ripple/src/language.js');
+const { create: createTypeScriptServices } = require('volar-service-typescript');
 
 const DEBUG = process.env.RIPPLE_DEBUG === 'true';
 
@@ -29,10 +30,23 @@ function createRippleLanguageServer() {
 			log('Initializing Ripple language server...');
 			log('Initialization options:', JSON.stringify(params.initializationOptions, null, 2));
 
+			const ts = require('typescript');
+
 			const initResult = server.initialize(
 				params,
-				createSimpleProject([getRippleLanguagePlugin()]),
-				[createRippleDiagnosticPlugin()],
+				createTypeScriptProject(
+					ts,
+					undefined,
+					() => {
+						return {
+							languagePlugins: [getRippleLanguagePlugin()],
+						};
+					}
+				),
+				[
+					createRippleDiagnosticPlugin(),
+					...createTypeScriptServices(ts),
+				],
 			);
 
 			log('Server initialization complete');

--- a/packages/ripple-language-server/src/server.js
+++ b/packages/ripple-language-server/src/server.js
@@ -1,0 +1,64 @@
+﻿const {
+	createConnection,
+	createServer,
+	createSimpleProject,
+} = require('@volar/language-server/node');
+const { createRippleDiagnosticPlugin } = require('./diagnosticPlugin.js');
+const { getRippleLanguagePlugin } = require('typescript-plugin-ripple/src/language.js');
+
+const DEBUG = process.env.RIPPLE_DEBUG === 'true';
+
+function log(...args) {
+	if (DEBUG) {
+		console.log('[Ripple Server]', ...args);
+	}
+}
+
+function logError(...args) {
+	console.error('[Ripple Server ERROR]', ...args);
+}
+
+function createRippleLanguageServer() {
+	const connection = createConnection();
+	const server = createServer(connection);
+
+	connection.listen();
+
+	connection.onInitialize(async (params) => {
+		try {
+			log('Initializing Ripple language server...');
+			log('Initialization options:', JSON.stringify(params.initializationOptions, null, 2));
+
+			const initResult = server.initialize(
+				params,
+				createSimpleProject([getRippleLanguagePlugin()]),
+				[createRippleDiagnosticPlugin()],
+			);
+
+			log('Server initialization complete');
+			return initResult;
+		} catch (initError) {
+			logError('Server initialization failed:', initError);
+			throw initError;
+		}
+	});
+
+	connection.onInitialized(() => {
+		log('Server initialized.');
+		server.initialized();
+	});
+
+	process.on('uncaughtException', (err) => {
+		logError('Uncaught exception:', err);
+	});
+
+	process.on('unhandledRejection', (reason, promise) => {
+		logError('Unhandled rejection at:', promise, 'reason:', reason);
+	});
+
+	return { connection, server };
+}
+
+module.exports = {
+	createRippleLanguageServer,
+};

--- a/packages/ripple-vscode-plugin/package.json
+++ b/packages/ripple-vscode-plugin/package.json
@@ -26,6 +26,7 @@
     "@volar/language-server": "~2.4.23",
     "@volar/typescript": "~2.4.23",
     "@volar/vscode": "~2.4.23",
+    "ripple-language-server": "workspace:*",
     "typescript-plugin-ripple": "workspace:*",
     "volar-service-typescript": "0.0.65",
     "vscode-languageclient": "^9.0.1",

--- a/packages/ripple-vscode-plugin/src/server.js
+++ b/packages/ripple-vscode-plugin/src/server.js
@@ -1,56 +1,8 @@
-const {
-	createConnection,
-	createServer,
-	createSimpleProject,
-} = require('@volar/language-server/node');
-const { createRippleDiagnosticPlugin } = require('./diagnosticPlugin.js');
-const { getRippleLanguagePlugin } = require('typescript-plugin-ripple/src/language.js');
+const { createRippleLanguageServer } = require('ripple-language-server/src/server.js');
 
-const connection = createConnection();
-const server = createServer(connection);
-
-const DEBUG = process.env.RIPPLE_DEBUG === 'true';
-
-function log(...args) {
-	if (DEBUG) {
-		console.log('[Ripple Server]', ...args);
-	}
+try {
+	createRippleLanguageServer();
+} catch (error) {
+	console.error('[Ripple Server] Failed to start:', error);
+	process.exit(1);
 }
-
-function logError(...args) {
-	console.error('[Ripple Server ERROR]', ...args);
-}
-
-connection.listen();
-
-connection.onInitialize(async (params) => {
-	try {
-		log('Initializing Ripple language server...');
-		log('Initialization options:', JSON.stringify(params.initializationOptions, null, 2));
-
-		const initResult = server.initialize(
-			params,
-			createSimpleProject([getRippleLanguagePlugin()]),
-			[createRippleDiagnosticPlugin()],
-		);
-
-		log('Server initialization complete');
-		return initResult;
-	} catch (initError) {
-		logError('Server initialization failed:', initError);
-		throw initError;
-	}
-});
-
-connection.onInitialized(() => {
-	log('Server initialized.');
-	server.initialized();
-});
-
-process.on('uncaughtException', (err) => {
-	logError('Uncaught exception:', err);
-})
-
-process.on('unhandledRejection', (reason, promise) => {
-	logError('Unhandled rejection at:', promise, 'reason:', reason);
-})

--- a/packages/ripple/src/compiler/phases/3-transform/segments.js
+++ b/packages/ripple/src/compiler/phases/3-transform/segments.js
@@ -978,7 +978,7 @@ export function convert_source_map_to_mappings(ast, source, generated_code) {
 					visit(node.typeAnnotation);
 				}
 				return;
-			} else if (node.type === 'Literal' || node.type === 'TSAnyKeyword' || node.type === 'TSUnknownKeyword' || node.type === 'TSNumberKeyword' || node.type === 'TSObjectKeyword' || node.type === 'TSBooleanKeyword' || node.type === 'TSBigIntKeyword' || node.type === 'TSStringKeyword' || node.type === 'TSSymbolKeyword' || node.type === 'TSVoidKeyword' || node.type === 'TSUndefinedKeyword' || node.type === 'TSNullKeyword' || node.type === 'TSNeverKeyword' || node.type === 'TSThisType' || node.type === 'TSIntrinsicKeyword') {
+			} else if (node.type === 'TSAnyKeyword' || node.type === 'TSUnknownKeyword' || node.type === 'TSNumberKeyword' || node.type === 'TSObjectKeyword' || node.type === 'TSBooleanKeyword' || node.type === 'TSBigIntKeyword' || node.type === 'TSStringKeyword' || node.type === 'TSSymbolKeyword' || node.type === 'TSVoidKeyword' || node.type === 'TSUndefinedKeyword' || node.type === 'TSNullKeyword' || node.type === 'TSNeverKeyword' || node.type === 'TSThisType' || node.type === 'TSIntrinsicKeyword') {
 				// Primitive type keywords - leaf nodes, no children
 				return;
 			}

--- a/packages/ripple/src/compiler/phases/3-transform/segments.js
+++ b/packages/ripple/src/compiler/phases/3-transform/segments.js
@@ -55,7 +55,7 @@ export function convert_source_map_to_mappings(ast, source, generated_code) {
 						continue; // Not a whole word match, keep searching
 					}
 				}
-				
+
 				sourceIndex = i + text.length;
 				return i;
 			}
@@ -87,7 +87,7 @@ export function convert_source_map_to_mappings(ast, source, generated_code) {
 						continue; // Not a whole word match, keep searching
 					}
 				}
-				
+
 				generatedIndex = i + text.length;
 				return i;
 			}
@@ -98,7 +98,7 @@ export function convert_source_map_to_mappings(ast, source, generated_code) {
 	// Collect text tokens from AST nodes
 	/** @type {string[]} */
 	const tokens = [];
-	
+
 	// We have to visit everything in generated order to maintain correct indices
 	walk(ast, null, {
 		_(node, { visit }) {
@@ -194,24 +194,24 @@ export function convert_source_map_to_mappings(ast, source, generated_code) {
 				return;
 			} else if (node.type === 'JSXElement') {
 				// Manually visit in source order: opening element, children, closing element
-				
+
 				// 1. Visit opening element (name and attributes)
 				if (node.openingElement) {
 					visit(node.openingElement);
 				}
-				
+
 				// 2. Visit children in order
 				if (node.children) {
 					for (const child of node.children) {
 						visit(child);
 					}
 				}
-				
+
 				// 3. Push closing tag name (not visited by AST walker)
 				if (!node.openingElement?.selfClosing && node.closingElement?.name?.type === 'JSXIdentifier') {
 					tokens.push(node.closingElement.name.name);
 				}
-				
+
 				return;
 			} else if (node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression') {
 				// Visit in source order: id, params, body
@@ -975,7 +975,7 @@ export function convert_source_map_to_mappings(ast, source, generated_code) {
 					visit(node.typeAnnotation);
 				}
 				return;
-			} else if (node.type === 'TSAnyKeyword' || node.type === 'TSUnknownKeyword' || node.type === 'TSNumberKeyword' || node.type === 'TSObjectKeyword' || node.type === 'TSBooleanKeyword' || node.type === 'TSBigIntKeyword' || node.type === 'TSStringKeyword' || node.type === 'TSSymbolKeyword' || node.type === 'TSVoidKeyword' || node.type === 'TSUndefinedKeyword' || node.type === 'TSNullKeyword' || node.type === 'TSNeverKeyword' || node.type === 'TSThisType' || node.type === 'TSIntrinsicKeyword') {
+			} else if (node.type === 'Literal' || node.type === 'TSAnyKeyword' || node.type === 'TSUnknownKeyword' || node.type === 'TSNumberKeyword' || node.type === 'TSObjectKeyword' || node.type === 'TSBooleanKeyword' || node.type === 'TSBigIntKeyword' || node.type === 'TSStringKeyword' || node.type === 'TSSymbolKeyword' || node.type === 'TSVoidKeyword' || node.type === 'TSUndefinedKeyword' || node.type === 'TSNullKeyword' || node.type === 'TSNeverKeyword' || node.type === 'TSThisType' || node.type === 'TSIntrinsicKeyword') {
 				// Primitive type keywords - leaf nodes, no children
 				return;
 			}
@@ -988,7 +988,7 @@ export function convert_source_map_to_mappings(ast, source, generated_code) {
 	for (const text of tokens) {
 		const sourcePos = findInSource(text);
 		const genPos = findInGenerated(text);
-		
+
 		if (sourcePos !== null && genPos !== null) {
 			mappings.push({
 				sourceOffsets: [sourcePos],

--- a/packages/typescript-plugin-ripple/src/language.js
+++ b/packages/typescript-plugin-ripple/src/language.js
@@ -143,17 +143,18 @@ class RippleVirtualCode {
 				getChangeRange: () => undefined,
 			};
 		} else {
-			// When compilation fails, use the original code as-is
-			// This way positions match exactly and we can provide diagnostics on raw text
-			log('Compilation failed, using original code for diagnostics');
+			// When compilation fails, show where it failed and disable all
+			// TypeScript diagnostics until the compilation error is fixed
+			log('Compilation failed, only display where the compilation error occurred.');
 
-			this.generatedCode = this.originalCode;
+			// Produce minimal valid TypeScript code to avoid cascading errors.
+			this.generatedCode = `export {};\n`;
 			this.isErrorMode = true; // Flag to indicate we're in diagnostic-only mode
 
 			// Create 1:1 mappings for the entire content
 			this.mappings = [
 				{
-					sourceOffsets: [0],
+					sourceOffsets: [this.errors[0]?.pos ?? 0],
 					generatedOffsets: [0],
 					lengths: [this.originalCode.length],
 					data: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,21 @@ importers:
         specifier: 'catalog:'
         version: 5.9.2
 
+  packages/ripple-language-server:
+    dependencies:
+      '@volar/language-server':
+        specifier: ~2.4.23
+        version: 2.4.23
+      typescript:
+        specifier: '>=5.0.0'
+        version: 5.9.2
+      typescript-plugin-ripple:
+        specifier: workspace:*
+        version: link:../typescript-plugin-ripple
+      vscode-uri:
+        specifier: ^3.1.0
+        version: 3.1.0
+
   packages/ripple-vscode-plugin:
     dependencies:
       '@jridgewell/sourcemap-codec':
@@ -144,6 +159,9 @@ importers:
       '@volar/vscode':
         specifier: ~2.4.23
         version: 2.4.23
+      ripple-language-server:
+        specifier: workspace:*
+        version: link:../ripple-language-server
       typescript-plugin-ripple:
         specifier: workspace:*
         version: link:../typescript-plugin-ripple

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       typescript-plugin-ripple:
         specifier: workspace:*
         version: link:../typescript-plugin-ripple
+      volar-service-typescript:
+        specifier: 0.0.65
+        version: 0.0.65(@volar/language-service@2.4.23)
       vscode-uri:
         specifier: ^3.1.0
         version: 3.1.0


### PR DESCRIPTION
Closes #409

This PR extracts the LSP from the VS Code extension into its own package. The idea is to use the LSP in other editors. I successfully tested it in WebStorm, Sublime Text, and Neovim. Before I change the PR from draft, I have a few questions I'd like to ask people who understand the codebase better. Probably @trueadm and @leonidaz.

1) This:
```js
const initResult = server.initialize(
	params,
	createSimpleProject([getRippleLanguagePlugin()]),
	[createRippleDiagnosticPlugin()],
);
```
seems to work in VS Code, but not in any other editor. All other editors correctly display compilation errors, but no TypeScript suggestions. I replaced `createSimpleProject` with `createTypeScriptProject`:
```js
const ts = require('typescript');

const initResult = server.initialize(
	params,
	createTypeScriptProject(
		ts,
		undefined,
		() => {
			return {
				languagePlugins: [getRippleLanguagePlugin()],
			};
		}
	),
	[
		createRippleDiagnosticPlugin(),
		...createTypeScriptServices(ts),
	],
);
```
With these changes it works everywhere, including VS Code. Is this change okay?

2) ~~The LSP was crashing with the error message `Unhandled AST node type in mapping walker: Literal` until I added a new condition to the list of skipped types in `packages/ripple/src/compiler/phases/3-transform/segments.js`:~~ This has been resolved.
```js
else if (node.type === 'Literal' || /* a long list of other types */) {
	// Primitive type keywords - leaf nodes, no children
	return;
}
```

3) The LSP seems to freak out when you make a syntax error, highlighting a lot of stuff as errors until you fix the actual error. This happens because when Ripple compilation fails, it falls back to treating the file as a regular TypeScript file, which will always fail since .ripple files aren't valid .ts files. I made it not provide any TypeScript diagnostics until Ripple compilation issue is fixed. Is this behavior good enough?
<img width="338" height="385" alt="image" src="https://github.com/user-attachments/assets/2762b09b-4081-40c2-b099-3b14aed3338e" />

## Demo screenshots

WebStorm
<img width="552" height="464" alt="image" src="https://github.com/user-attachments/assets/49de775c-343e-4b75-87b0-9c1bcdd4f2c7" />

Sublime Text
<img width="782" height="379" alt="image" src="https://github.com/user-attachments/assets/6daa5021-f06b-49f8-a7e6-94548a3306d5" />

Neovim
<img width="414" height="368" alt="image" src="https://github.com/user-attachments/assets/21392ea6-23f8-4a49-86a4-f0d0357cfbf5" />

## TODO
- [ ] Write installation instructions for popular editors.
- [x] Verify that VS Code extension still correctly builds. I only tested it unpacked.
> [!NOTE]
> It should correctly build once the language server is published on npm, since it uses yarn to build, and yarn doesn't work with pnpm's workspaces. It ignores them and tries to pull the package from the registry anyway.
- [ ] Someone will need to claim the package name on npm.
- [ ] Update documentation.
- [x] Potentially fix the fallback to TypeScript on compilation errors?